### PR TITLE
fix(pagination): updating Pagination.totalPages

### DIFF
--- a/components/pagination/pagination.ts
+++ b/components/pagination/pagination.ts
@@ -138,7 +138,7 @@ export class Pagination implements ControlValueAccessor, OnInit, IPaginationConf
     this._totalPages = v;
     this.numPages.next(v);
     if (this.inited) {
-      this.selectPage(v);
+      this.selectPage(this.page);
     }
   }
 


### PR DESCRIPTION
When updating `Pagination.totalPages` after total amount of items
changed it goes to the last page (by calling
`this.selectPage(totalPages)`).

Instead, if at all, it should go to `this.page`.
