### PR TITLE
(fix) Add more explicit types for EventEmitter<T>

### DIFF
--- a/components/alert/alert.ts
+++ b/components/alert/alert.ts
@@ -25,7 +25,7 @@ import {
 })
 export class Alert implements OnInit {
   public type:string;
-  public close:EventEmitter = new EventEmitter();
+  public close:EventEmitter<Alert> = new EventEmitter();
   public templateUrl:string;
   public dismissOnTimeout:number;
 

--- a/components/datepicker/datepicker-inner.ts
+++ b/components/datepicker/datepicker-inner.ts
@@ -114,7 +114,7 @@ export class DatePickerInner implements OnInit {
   private compareHandlerMonth:Function;
   private refreshViewHandlerYear:Function;
   private compareHandlerYear:Function;
-  private update:EventEmitter = new EventEmitter();
+  private update:EventEmitter<Date> = new EventEmitter();
 
   private get initDate():Date {
     return this._initDate;

--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -19,7 +19,7 @@ export class Dropdown implements OnInit, OnDestroy {
   private _isOpen:boolean;
   // enum string: ['always', 'outsideClick', 'disabled']
   private dropdownAppendToBody:boolean;
-  private onToggle:EventEmitter = new EventEmitter();
+  private onToggle:EventEmitter<boolean> = new EventEmitter();
 
   public autoClose:string;
   public keyboardNav:boolean;

--- a/components/pagination/pagination.ts
+++ b/components/pagination/pagination.ts
@@ -29,6 +29,10 @@ export interface IPaginationConfig extends IAttribute {
 
   rotate: boolean;
 }
+interface IPageChangedEvent {
+  itemsPerPage: number;
+  page: number;
+}
 const paginationConfig:IPaginationConfig = {
   maxSize: void 0,
   itemsPerPage: 10,
@@ -103,8 +107,8 @@ export class Pagination implements ControlValueAccessor, OnInit, IPaginationConf
   private classMap:string;
 
   private disabled:boolean;
-  private numPages:EventEmitter = new EventEmitter();
-  private pageChanged:EventEmitter = new EventEmitter();
+  private numPages:EventEmitter<number> = new EventEmitter();
+  private pageChanged:EventEmitter<IPageChangedEvent> = new EventEmitter();
 
   private _itemsPerPage:number;
   private _totalItems:number;

--- a/components/rating/rating.ts
+++ b/components/rating/rating.ts
@@ -40,8 +40,8 @@ export class Rating implements ControlValueAccessor, OnInit {
   private readonly:boolean;
   private ratingStates:Array<{stateOn:string, stateOff:string}>;
 
-  private onHover:EventEmitter = new EventEmitter();
-  private onLeave:EventEmitter = new EventEmitter();
+  private onHover:EventEmitter<number> = new EventEmitter();
+  private onLeave:EventEmitter<number> = new EventEmitter();
 
   constructor(@Self() public cd:NgModel) {
     cd.valueAccessor = this;

--- a/components/tabs/tabs.ts
+++ b/components/tabs/tabs.ts
@@ -89,8 +89,8 @@ export class Tab implements OnInit, OnDestroy, DoCheck {
 
   public headingRef:TemplateRef;
 
-  public select:EventEmitter = new EventEmitter();
-  public deselect:EventEmitter = new EventEmitter();
+  public select:EventEmitter<Tab> = new EventEmitter();
+  public deselect:EventEmitter<Tab> = new EventEmitter();
 
   constructor(public tabset:Tabset) {
     this.tabset.addTab(this);

--- a/components/typeahead/typeahead.ts
+++ b/components/typeahead/typeahead.ts
@@ -182,9 +182,9 @@ export class TypeaheadContainer {
   }
 })
 export class Typeahead implements OnInit {
-  public typeaheadLoading:EventEmitter = new EventEmitter();
-  public typeaheadNoResults:EventEmitter = new EventEmitter();
-  public typeaheadOnSelect:EventEmitter = new EventEmitter();
+  public typeaheadLoading:EventEmitter<boolean> = new EventEmitter();
+  public typeaheadNoResults:EventEmitter<boolean> = new EventEmitter();
+  public typeaheadOnSelect:EventEmitter<{item: string}> = new EventEmitter();
 
   public container:TypeaheadContainer;
 


### PR DESCRIPTION
This is required for Angular Angular 2.0.0-alpha.46 to remove compiler
errors like:
error TS2314: Generic type 'EventEmitter<T>' requires 1 type argument(s).

Relates #34
