### PR TITLE
comp(typeahead): numeric sources (ie. years)

### DIFF
--- a/components/typeahead/typeahead.ts
+++ b/components/typeahead/typeahead.ts
@@ -143,7 +143,7 @@ export class TypeaheadContainer {
 
   private hightlight(item:string, query:string) {
     // Replaces the capture string with a the same string inside of a "strong" tag
-    return query ? item.replace(new RegExp(this.escapeRegexp(query), 'gi'), '<strong>$&</strong>') : item;
+    return query ? item.toString().replace(new RegExp(this.escapeRegexp(query), 'gi'), '<strong>$&</strong>') : item;
   };
 }
 
@@ -281,7 +281,7 @@ export class Typeahead implements OnInit {
           continue;
         }
 
-        if (match.toLowerCase().indexOf(this.cd.model.toString().toLowerCase()) >= 0) {
+        if (match.toString().toLowerCase().indexOf(this.cd.model.toString().toLowerCase()) >= 0) {
           this._matches.push(match);
           if (this._matches.length > this.optionsLimit - 1) {
             break;


### PR DESCRIPTION
When numeric sources an error was thrown:

``` javascript
    private years: Array<any> = [];
    private getYears() {
        if ((this.years.lenght >>> 0) === 0) {
            for (var i = yearNow; i >= minYear; i -= 1) {
                var yearNow = new Date().getFullYear() - 16,
                    minYear = yearNow - 100;

                this.years.push({
                    id: i,
                    description: i
                });
            }
        }
        return this.years;
    }
```

``` html
<input [typeahead]="getYears()" (typeahead-on-select)="onSelectYear($event)" [typeahead-option-field]="'id'" [placeholder]="'Year'">
```

```
TypeError: match.toLowerCase is not a function
    at Typeahead.processMatches (http://127.0.0.1:8080/public/node_modules/ng2-bootstrap/components/typeahead/typeahead.js:182:27)
    at Typeahead.onChange (http://127.0.0.1:8080/public/node_modules/ng2-bootstrap/components/typeahead/typeahead.js:272:18)
    at AbstractChangeDetector.ChangeDetector_TypeaheadDiba_0.handleEventInternal (eval at <anonymous> (http://127.0.0.1:8080/node_modules/angular2/bundles/angular2.dev.js:22300:14), <anonymous>:384:36)
    at AbstractChangeDetector.handleEvent (http://127.0.0.1:8080/node_modules/angular2/bundles/angular2.dev.js:22051:22)
    at AppView.dispatchEvent (http://127.0.0.1:8080/node_modules/angular2/bundles/angular2.dev.js:18939:39)
    at AppView.dispatchRenderEvent (http://127.0.0.1:8080/node_modules/angular2/bundles/angular2.dev.js:18934:19)
    at DefaultRenderView.dispatchRenderEvent (http://127.0.0.1:8080/node_modules/angular2/bundles/angular2.dev.js:14785:53)
    at eventDispatcher (http://127.0.0.1:8080/node_modules/angular2/bundles/angular2.dev.js:19876:19)
    at http://127.0.0.1:8080/node_modules/angular2/bundles/angular2.dev.js:19947:14
    at http://127.0.0.1:8080/node_modules/angular2/bundles/angular2.dev.js:28650:34
```
