### PR TITLE
chore(Update): update to `2.0.0-beta.0`. also fixed naming convention…

### DIFF
--- a/components/accordion/accordion.ts
+++ b/components/accordion/accordion.ts
@@ -135,6 +135,6 @@ export class AccordionHeading {
   }
 }
 
-export const ACCORDION_COMPONENTS:Array<any> = [Accordion, AccordionGroup, AccordionHeading];
+export const ACCORDION_DIRECTIVES:Array<any> = [Accordion, AccordionGroup, AccordionHeading];
 // will be deprecated
 export const accordion:Array<any> = [Accordion, AccordionGroup, AccordionHeading];

--- a/components/accordion/readme.md
+++ b/components/accordion/readme.md
@@ -1,6 +1,6 @@
 ### Usage
 ```typescript
-import { ACCORDION_COMPONENTS } from 'ng2-bootstrap/ng2-bootstrap';
+import { ACCORDION_DIRECTIVES } from 'ng2-bootstrap/ng2-bootstrap';
 ```
 
 ### Annotations
@@ -41,7 +41,7 @@ export class AccordionHeading {
   constructor(private group:AccordionGroup, private templateRef:TemplateRef) {}
 
 
-export const ACCORDION_COMPONENTS:Array<any> = [Accordion, AccordionGroup, AccordionHeading];
+export const ACCORDION_DIRECTIVES:Array<any> = [Accordion, AccordionGroup, AccordionHeading];
 ```
 
 ### Accordion properties

--- a/components/carousel/carousel.ts
+++ b/components/carousel/carousel.ts
@@ -232,6 +232,6 @@ export class Slide implements OnInit, OnDestroy {
   }
 }
 
-export const CAROUSEL_COMPONENTS:Array<any> = [Carousel, Slide];
+export const CAROUSEL_DIRECTIVES:Array<any> = [Carousel, Slide];
 // will be deprecated
 export const carousel:Array<any> = [Carousel, Slide];

--- a/components/carousel/readme.md
+++ b/components/carousel/readme.md
@@ -1,6 +1,6 @@
 ### Usage
 ```typescript
-import { CAROUSEL_COMPONENTS } from 'ng2-bootstrap/ng2-bootstrap';
+import { CAROUSEL_DIRECTIVES } from 'ng2-bootstrap/ng2-bootstrap';
 ```
 
 ### Annotations
@@ -35,7 +35,7 @@ export class Slide implements OnInit, OnDestroy {
   private addClass:boolean = true;
 }
 
-export const CAROUSEL_COMPONENTS:Array<any> = [Carousel, Slide];
+export const CAROUSEL_DIRECTIVES:Array<any> = [Carousel, Slide];
 ```
 
 ### Carousel properties

--- a/components/pagination/pagination.ts
+++ b/components/pagination/pagination.ts
@@ -323,9 +323,9 @@ export class Pager extends Pagination implements OnInit {
   }
 }
 
-export const PAGINATION_COMPONENTS:Array<any> = [Pagination, Pager];
+export const PAGINATION_DIRECTIVES:Array<any> = [Pagination, Pager];
 /**
- * @deprecated - use PAGINATION_COMPONENTS instead
+ * @deprecated - use PAGINATION_DIRECTIVES instead
  * @type {Pagination|Pager[]}
  */
 export const pagination:Array<any> = [Pagination, Pager];

--- a/components/pagination/readme.md
+++ b/components/pagination/readme.md
@@ -1,6 +1,6 @@
 ### Usage
 ```typescript
-import { PAGINATION_COMPONENTS } from 'ng2-bootstrap/ng2-bootstrap';
+import { PAGINATION_DIRECTIVES } from 'ng2-bootstrap/ng2-bootstrap';
 ```
 
 ### Annotations
@@ -40,7 +40,7 @@ export class Pagination implements ControlValueAccessor, OnInit, IPaginationConf
   ]
 })
 
-export const PAGINATION_COMPONENTS:Array<any> = [Pagination, Pager];
+export const PAGINATION_DIRECTIVES:Array<any> = [Pagination, Pager];
 ```
 ### Pagination properties
   - `rotate` (`?boolean=true`) - if `true` current page will in the middle of pages list

--- a/components/progressbar/progressbar.ts
+++ b/components/progressbar/progressbar.ts
@@ -134,9 +134,9 @@ export class Progressbar {
   @Input() private value:number;
 }
 
-export const PROGRESSBAR_COMPONENTS:Array<any> = [Progress, Bar, Progressbar];
+export const PROGRESSBAR_DIRECTIVES:Array<any> = [Progress, Bar, Progressbar];
 /**
- * @deprecated use PROGRESSBAR_COMPONENTS instead
+ * @deprecated use PROGRESSBAR_DIRECTIVES instead
  * @type {Progress|Bar|Progressbar[]}
  */
 export const progressbar:Array<any> = [Progress, Bar, Progressbar];

--- a/components/progressbar/readme.md
+++ b/components/progressbar/readme.md
@@ -1,6 +1,6 @@
 ### Usage
 ```typescript
-import { PROGRESSBAR_COMPONENTS } from 'ng2-bootstrap/ng2-bootstrap';
+import { PROGRESSBAR_DIRECTIVES } from 'ng2-bootstrap/ng2-bootstrap';
 ```
 
 ### Annotations

--- a/components/tabs/readme.md
+++ b/components/tabs/readme.md
@@ -1,6 +1,6 @@
 ### Usage
 ```typescript
-import { TAB_COMPONENTS } from 'ng2-bootstrap/ng2-bootstrap';
+import { TAB_DIRECTIVES } from 'ng2-bootstrap/ng2-bootstrap';
 ```
 
 ```html
@@ -44,7 +44,7 @@ export class Tab implements OnInit, OnDestroy, DoCheck {
 @Directive({selector: '[tab-heading]'})
 export class TabHeading {}
 
-export const TAB_COMPONENTS:Array<any> = [Tab, TabHeading, Tabset];
+export const TAB_DIRECTIVES:Array<any> = [Tab, TabHeading, Tabset];
 ```
 
 ### Tabset properties

--- a/components/tabs/tabs.ts
+++ b/components/tabs/tabs.ts
@@ -132,9 +132,9 @@ export class TabHeading {
   }
 }
 
-export const TAB_COMPONENTS:Array<any> = [Tab, TabHeading, Tabset];
+export const TAB_DIRECTIVES:Array<any> = [Tab, TabHeading, Tabset];
 /**
- * @deprecated - use TAB_COMPONENTS instead
+ * @deprecated - use TAB_DIRECTIVES instead
  * @type {Tab|TabHeading|Tabset[]}
  */
 export const tabs:Array<any> = [Tab, TabHeading, Tabset];

--- a/components/tooltip/readme.md
+++ b/components/tooltip/readme.md
@@ -1,6 +1,6 @@
 ### Usage
 ```typescript
-import { TOOLTIP_COMPONENTS } from 'ng2-bootstrap/ng2-bootstrap';
+import { TOOLTIP_DIRECTIVES } from 'ng2-bootstrap/ng2-bootstrap';
 ```
 
 ### Annotations

--- a/components/tooltip/tooltip.ts
+++ b/components/tooltip/tooltip.ts
@@ -126,7 +126,7 @@ export class Tooltip implements OnInit {
   }
 }
 
-export const TOOLTIP_COMPONENTS:Array<any> = [Tooltip, TooltipContainer];
+export const TOOLTIP_DIRECTIVES:Array<any> = [Tooltip, TooltipContainer];
 /**
  * @deprecated
  * @type {Tooltip|TooltipContainer[]}

--- a/demo/components/accordion/accordion-demo.ts
+++ b/demo/components/accordion/accordion-demo.ts
@@ -4,7 +4,7 @@ import {
   Component, View,
 } from 'angular2/core';
 import { CORE_DIRECTIVES, FORM_DIRECTIVES, NgFor } from 'angular2/common';
-import { ACCORDION_COMPONENTS } from '../../../ng2-bootstrap';
+import { ACCORDION_DIRECTIVES } from '../../../ng2-bootstrap';
 
 // webpack html imports
 let template = require('./accordion-demo.html');
@@ -14,7 +14,7 @@ let template = require('./accordion-demo.html');
 })
 @View({
   template: template,
-  directives: [ACCORDION_COMPONENTS, CORE_DIRECTIVES, FORM_DIRECTIVES]
+  directives: [ACCORDION_DIRECTIVES, CORE_DIRECTIVES, FORM_DIRECTIVES]
 })
 export class AccordionDemo {
   public oneAtATime:boolean = true;

--- a/demo/components/carousel/carousel-demo.ts
+++ b/demo/components/carousel/carousel-demo.ts
@@ -2,14 +2,14 @@
 
 import { Component } from 'angular2/core';
 import { CORE_DIRECTIVES, FORM_DIRECTIVES } from 'angular2/common';
-import { CAROUSEL_COMPONENTS } from '../../../ng2-bootstrap';
+import { CAROUSEL_DIRECTIVES } from '../../../ng2-bootstrap';
 
 // webpack html imports
 let template = require('./carousel-demo.html');
 
 @Component({
   selector: 'carousel-demo',
-  directives: [CAROUSEL_COMPONENTS, CORE_DIRECTIVES, FORM_DIRECTIVES],
+  directives: [CAROUSEL_DIRECTIVES, CORE_DIRECTIVES, FORM_DIRECTIVES],
   template: template
 })
 export class CarouselDemo {

--- a/demo/components/pagination/pagination-demo.ts
+++ b/demo/components/pagination/pagination-demo.ts
@@ -3,7 +3,7 @@ import {
   Component, View,
 } from 'angular2/core';
 import { CORE_DIRECTIVES, FORM_DIRECTIVES } from 'angular2/common';
-import { PAGINATION_COMPONENTS } from '../../../ng2-bootstrap';
+import { PAGINATION_DIRECTIVES } from '../../../ng2-bootstrap';
 
 // webpack html imports
 let template = require('./pagination-demo.html');
@@ -13,7 +13,7 @@ let template = require('./pagination-demo.html');
 })
 @View({
   template: template,
-  directives: [PAGINATION_COMPONENTS, FORM_DIRECTIVES, CORE_DIRECTIVES]
+  directives: [PAGINATION_DIRECTIVES, FORM_DIRECTIVES, CORE_DIRECTIVES]
 })
 export class PaginationDemo {
   private totalItems:number = 64;

--- a/demo/components/tabs/tabs-demo.ts
+++ b/demo/components/tabs/tabs-demo.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../../tsd.d.ts" />
 import { Component } from 'angular2/core';
 import { CORE_DIRECTIVES } from 'angular2/common';
-import { TAB_COMPONENTS } from '../../../ng2-bootstrap';
+import { TAB_DIRECTIVES } from '../../../ng2-bootstrap';
 
 // webpack html imports
 let template = require('./tabs-demo.html');
@@ -9,7 +9,7 @@ let template = require('./tabs-demo.html');
 @Component({
   selector: 'tabs-demo',
   template: template,
-  directives: [TAB_COMPONENTS, CORE_DIRECTIVES]
+  directives: [TAB_DIRECTIVES, CORE_DIRECTIVES]
 })
 export class TabsDemo {
   private tabs:Array<any> = [

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -3,7 +3,7 @@ import {
   Component, View,
 } from 'angular2/core';
 import { CORE_DIRECTIVES } from 'angular2/common';
-import { bootstrap } from 'angular2/bootstrap';
+import { bootstrap } from 'angular2/platform/browser';
 
 import {Ng2BootstrapConfig, Ng2BootstrapTheme} from '../ng2-bootstrap';
 

--- a/ng2-bootstrap.ts
+++ b/ng2-bootstrap.ts
@@ -19,4 +19,4 @@ export * from  './components/tooltip/tooltip';
 export * from  './components/typeahead/typeahead';
 export * from  './components/position'
 export * from  './components/common'
-export * from './components/ng2-bootstrap-config';
+export * from  './components/ng2-bootstrap-config';

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/valor-software/ng2-bootstrap#readme",
   "dependencies": {},
   "devDependencies": {
-    "angular2": "2.0.0-alpha.53",
+    "angular2": "2.0.0-beta.0",
     "balanced-match": "0.3.0",
     "bootstrap": "3.3.6",
     "clean-webpack-plugin": "0.1.5",
@@ -54,7 +54,7 @@
     "raw-loader": "0.5.1",
     "reflect-metadata": "0.1.2",
     "require-dir": "0.3.0",
-    "rxjs": "5.0.0-alpha.14",
+    "rxjs": "5.0.0-beta.0",
     "ts-loader": "0.7.2",
     "tslint": "3.2.0",
     "typescript": "1.7.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,7 @@ var config = {
   entry: {
     angular2: [
       // Angular 2 Deps
-      'zone.js',
+      'zone.js/dist/zone-microtask',
       'reflect-metadata',
       'angular2/common',
       'angular2/core'
@@ -125,7 +125,8 @@ var config = {
     ],
     noParse: [
       /rtts_assert\/src\/rtts_assert/,
-      /reflect-metadata/
+      /reflect-metadata/,
+      /zone\.js\/dist\/zone-microtask/
     ]
   },
 


### PR DESCRIPTION
Upgraded to `2.0.0-beta.0`.

Also Following up on this comment:
https://github.com/valor-software/ng2-bootstrap/commit/0989ed79d4ac165ffcd978301ec1caf86c093e7d#diff-4f4a50942b505a114eb9ebb3e2d6a692R44

@valorkin This gets it the bulk of the way there for the upgrade. 
I ran out of time tonight, but you can safely merge and fix this small issue quickly (probably just a tweak in `Tabset` needed):

```
Error: Expression 'classMap in Tabset@1:20' has changed after it was checked. Previous value: '[object Object]'. Current value: '[object Object]'
    at ExpressionChangedAfterItHasBeenCheckedException.BaseException [as constructor] (http://localhost:8080/build/angular2.js:1438:24)
    at new ExpressionChangedAfterItHasBeenCheckedException (http://localhost:8080/build/angular2.js:18515:17)
```
