### PR TITLE
comp(typeahead) Bug: inner-html => innerHtml (BS3)

### DIFF
--- a/components/typeahead/typeahead.ts
+++ b/components/typeahead/typeahead.ts
@@ -46,7 +46,7 @@ const TEMPLATE:any = {
     <li *ngFor="#match of matches"
         [ngClass]="{active: isActive(match) }"
         (mouseenter)="selectActive(match)">
-        <a href="#" (click)="selectMatch(match, $event)" tabindex="-1" [inner-html]="hightlight(match, query)"></a>
+        <a href="#" (click)="selectMatch(match, $event)" tabindex="-1" [innerHtml]="hightlight(match, query)"></a>
     </li>
   </ul>
   `


### PR DESCRIPTION
In angular2 beta it is no longer supported `[inner-html]`, it should be `[innerHtml]`
