### PR TITLE
Corrected systemjs-bundle config meta - now using cwd.

### DIFF
--- a/make.js
+++ b/make.js
@@ -48,7 +48,7 @@ function getSystemJsBundleConfig(cb) {
   };
 
   config.meta = ['angular2', 'rxjs'].reduce((memo, currentValue) => {
-    memo[`${name}/node_modules/${currentValue}/*`] = {build: false};
+    memo[`${__dirname}/node_modules/${currentValue}/*`] = {build: false};
     return memo;
   }, {});
   return cb(null, config);


### PR DESCRIPTION
Build process now does not require the local clone of the repository to be in a folder called **ng2-bootstrap**.
Please read the commits comment for more details on the issue.
