### PR TITLE
Fix: bundling systemjs-builder was still reading compiled files from clone/../ng2-bootstrap folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,13 +15,5 @@ npm-debug.log
 /bundles
 
 # ignore incline compiling
-/demo/**/*.js
-/demo/**/*.js.map
-/demo/**/*.d.ts
-/components/**/*.js
-/components/**/*.js.map
-/components/**/*.d.ts
-ng2-bootstrap.js
-ng2-bootstrap.d.ts
-ng2-bootstrap.js.map
+/ng2-bootstrap
 /logs

--- a/make.js
+++ b/make.js
@@ -32,7 +32,7 @@ async.waterfall([
 
 function getSystemJsBundleConfig(cb) {
   let config = {
-    baseURL: '..',
+    baseURL: '.',
     transpiler: 'typescript',
     typescriptOptions: {
       module: 'cjs'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "experimentalDecorators": true,
     "noImplicitAny": true,
     "listFiles": false,
-    "noLib": false
+    "noLib": false,
+    "outDir": "./ng2-bootstrap"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
### Issue

The bundling is reading compiled files from `../ng2-bootstrap` folder.
### How to reproduce

create a new, empty folder

```
$ mkdir parent
$ cd parent
parent$ git clone https://github.com/valor-software/ng2-bootstrap.git myclone
parent$ cd myclone
parent/myclone$ npm i
...
parent/myclone$ ./make.js
Deleted files and folders:

Bundling system.js file: ng2-bootstrap.js {}
Unhandled rejection Error on fetch for ng2-bootstrap/ng2-bootstrap at file:///parent/ng2-bootstrap/ng2-bootstrap.js
    Error: ENOENT: no such file or directory, open '/parent/ng2-bootstrap/ng2-bootstrap.js'
    at Error (native)
```

---

First, adding to `tsconfig.json` the output directory as `outDir:'./ng2-bootstrap'` will make `tsc` compile the javascript files into that folder.
With this in place, there is no need to point the `baseURL` to the parent folder any more (systemjs-builder config).

Added bonus is that the compiled js files do not scatter around the source directory (modified `.gitignore`). Nice and tidy!
