### PR TITLE
Fix #124: dropdown outside

### DIFF
--- a/components/dropdown.ts
+++ b/components/dropdown.ts
@@ -1,6 +1,8 @@
 import {Dropdown} from './dropdown/dropdown.directive';
+import {DropdownMenu} from './dropdown/dropdown-menu.directive';
 import {DropdownToggle} from './dropdown/dropdown-toggle.directive';
 
 export {Dropdown} from './dropdown/dropdown.directive';
+export {DropdownMenu} from './dropdown/dropdown-menu.directive';
 export {DropdownToggle} from './dropdown/dropdown-toggle.directive';
-export const DROPDOWN_DIRECTIVES: Array<any> = [Dropdown, DropdownToggle];
+export const DROPDOWN_DIRECTIVES: Array<any> = [Dropdown, DropdownToggle, DropdownMenu];

--- a/components/dropdown/dropdown-menu.directive.ts
+++ b/components/dropdown/dropdown-menu.directive.ts
@@ -1,0 +1,16 @@
+import {
+  Directive, ElementRef, Host,
+  OnInit
+} from 'angular2/core';
+
+import {Dropdown} from './dropdown.directive';
+
+@Directive({ selector: '[dropdownMenu]' })
+export class DropdownMenu implements OnInit {
+  constructor( @Host() public dropdown: Dropdown, public el: ElementRef) {
+  }
+
+  public ngOnInit() {
+    this.dropdown.dropDownMenu = this;
+  }
+}

--- a/components/dropdown/dropdown.service.ts
+++ b/components/dropdown/dropdown.service.ts
@@ -50,7 +50,7 @@ export class DropdownService {
 
     if (event && this.openScope.autoClose === OUTSIDECLICK &&
       this.openScope.menuEl &&
-      this.openScope.menuEl.nativeElement === event.target) {
+      this.openScope.menuEl.nativeElement.contains(event.target)) {
       return;
     }
 


### PR DESCRIPTION
This fixes #124 by
- ensuring that `dropdown.menuEl` is set
- improving the "clicked element is inside menu" test
