### PR TITLE
feat: implement "nonInput" auto-close mode

### DIFF
--- a/components/dropdown/dropdown.directive.ts
+++ b/components/dropdown/dropdown.directive.ts
@@ -5,7 +5,7 @@ import {
   Query, QueryList
 } from 'angular2/core';
 
-import {dropdownService, ALWAYS} from './dropdown.service';
+import {dropdownService, NONINPUT} from './dropdown.service';
 
 @Directive({selector: '[dropdown]'})
 export class Dropdown implements OnInit, OnDestroy {
@@ -56,7 +56,7 @@ export class Dropdown implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.autoClose = this.autoClose || ALWAYS;
+    this.autoClose = this.autoClose || NONINPUT;
     if (this.isOpen) {
       // todo: watch for event get-isOpen?
     }

--- a/components/dropdown/dropdown.service.ts
+++ b/components/dropdown/dropdown.service.ts
@@ -1,6 +1,7 @@
 export const ALWAYS = 'always';
 export const DISABLED = 'disabled';
 export const OUTSIDECLICK = 'outsideClick';
+export const NONINPUT = 'nonInput';
 
 import {Dropdown} from './dropdown.directive';
 
@@ -45,6 +46,13 @@ export class DropdownService {
 
     if (event && this.openScope.toggleEl &&
       this.openScope.toggleEl.nativeElement === event.target) {
+      return;
+    }
+
+    if (event && this.openScope.autoClose === NONINPUT &&
+      this.openScope.menuEl &&
+      /input|textarea/i.test((<any> event.target).tagName) &&
+      this.openScope.menuEl.nativeElement.contains(event.target)) {
       return;
     }
 

--- a/components/dropdown/readme.md
+++ b/components/dropdown/readme.md
@@ -24,7 +24,7 @@ export class Dropdown implements OnInit, OnDestroy {
   @Input() public get isOpen():boolean {}
   @Input() public autoClose:string;
   @Input() public keyboardNav:boolean;
-// enum string: ['always', 'outsideClick', 'disabled']
+// enum string: ['nonInput', always', 'outsideClick', 'disabled']
   @Input() public appendToBody:boolean;
   @Output() public onToggle:EventEmitter<boolean>;
 }
@@ -47,7 +47,8 @@ export const DROPDOWN_DIRECTIVES: Array<any> = [Dropdown, DropdownMenu, Dropdown
 ### Dropdown properties
 - `isOpen` (`?boolean=false`) - if `true` dropdown will be opened
 - `autoClose` (`?string='always'`) - behaviour vary:
-    * `always` - (default) automatically closes the dropdown when any of its elements is clicked
+    * `nonInput` - (default) automatically closes the dropdown when any of its elements is clicked — as long as the clicked element is not an `input` or a `textarea`.
+    * `always` - automatically closes the dropdown when any of its elements is clicked
     * `outsideClick` - closes the dropdown automatically only when the user clicks any element outside the dropdown
     * `disabled` - disables the auto close. You can then control the open/close status of the dropdown manually, by using `is-open`. Please notice that the dropdown will still close if the toggle is clicked, the `esc` key is pressed or another dropdown is open
 - `keyboardNav` (`?boolean=false`) - if `true` will enable navigation of dropdown list elements with the arrow keys


### PR DESCRIPTION
… because that’s what [the original Boostrap 4 code does](https://github.com/twbs/bootstrap/blob/a1bf344c4f041ad88acaf5b2b3777c733d3afe40/js/src/dropdown.js#L174-L176).
- Add NONINPUT constant and copy Bootstrap’s behavior
- Change the default auto-close behaviour to `NONINPUT`
- Add `nonInput` to documentation / readme
