### PR TITLE
fix(demo): including es6-shim and es6-promise

### DIFF
--- a/polyfills.ts
+++ b/polyfills.ts
@@ -1,0 +1,3 @@
+// Polyfills
+import 'es6-shim';
+import 'es6-promise';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,6 +44,7 @@ var config = {
   },
 
   entry: {
+    polyfills: 'polyfills',
     angular2: [
       // Angular 2 Deps
       'zone.js/dist/zone-microtask',
@@ -121,9 +122,9 @@ var config = {
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurenceOrderPlugin(true),
     new webpack.optimize.CommonsChunkPlugin({
-      name: 'angular2',
-      minChunks: Infinity,
-      filename: 'angular2.js'
+      name: 'polyfills',
+      filename: 'polyfills.js',
+      minChunks: Infinity
     }),
     // static assets
     new CopyWebpackPlugin([{from: 'demo/favicon.ico', to: 'favicon.ico'}]),


### PR DESCRIPTION
Added es6-shim and es6-promise for browsers without es6 support.

Demo: https://dl.dropboxusercontent.com/u/19031145/ng2-bootstrap/index.html
It got rid of the error `Object doesn't support property or method` in IE11, but now it throws:

```
SyntaxError: The use of a keyword for an indentifier is invalid
```

So maybe I broke something else.
