### PR TITLE
Update datepicker-inner.ts: showWeeks

### DIFF
--- a/components/datepicker/datepicker-inner.ts
+++ b/components/datepicker/datepicker-inner.ts
@@ -131,7 +131,7 @@ export class DatePickerInner implements OnInit {
     this.formatDayHeader = this.formatDayHeader || FORMAT_DAY_HEADER;
     this.formatDayTitle = this.formatDayTitle || FORMAT_DAY_TITLE;
     this.formatMonthTitle = this.formatMonthTitle || FORMAT_MONTH_TITLE;
-    this.showWeeks = !!this.showWeeks || SHOW_WEEKS;
+    this.showWeeks = (this.showWeeks === undefined ? SHOW_WEEKS : this.showWeeks);
     this.startingDay = this.startingDay || STARTING_DAY;
     this.yearRange = this.yearRange || YEAR_RANGE;
     this.shortcutPropagation = this.shortcutPropagation || SHORTCUT_PROPAGATION;


### PR DESCRIPTION
_!!this.showWeeks || SHOW_WEEKS;_

When _SHOW_WEEKS=false_ - the assigned value will always be correct:
- this.showWeeks = undefined -> false
- this.showWeeks = false -> false
- this.showWeeks = true -> true

But, when _SHOW_WEEKS=true_ - the assigned value will NOT always be correct:
- this.showWeeks = undefined -> true
- **this.showWeeks = false -> true**
- this.showWeeks = true -> true
