### PR TITLE
Fix tooltip position.

### DIFF
--- a/components/tooltip/tooltip-container.component.ts
+++ b/components/tooltip/tooltip-container.component.ts
@@ -2,7 +2,7 @@ import {
   Component,
   OnInit, Input, HostListener,
   ElementRef, EventEmitter,
-  DynamicComponentLoader, ComponentRef, Inject
+  DynamicComponentLoader, ComponentRef, Inject, AfterViewChecked
 } from 'angular2/core';
 import {NgClass, NgStyle} from 'angular2/common';
 import {positionService} from '../position';
@@ -11,17 +11,16 @@ import {TooltipOptions} from './tooltip-options.class';
 @Component({
   selector: 'tooltip-container',
   directives: [NgClass, NgStyle],
-  template: `
-    <div class="tooltip" role="tooltip"
+  template: `<div class="tooltip" role="tooltip"
      [ngStyle]="{top: top, left: left, display: display}"
-     [ngClass]="classMap" >
+     [ngClass]="classMap">
       <div class="tooltip-arrow"></div>
       <div class="tooltip-inner">
         {{content}}
       </div>
     </div>`
 })
-export class TooltipContainer {
+export class TooltipContainer implements AfterViewChecked {
   private classMap:any;
   private positionMap:any;
   private top:string;
@@ -32,6 +31,7 @@ export class TooltipContainer {
   private appendToBody:boolean;
 
   private isOpen:boolean;
+  private hostEl:ElementRef;
 
   constructor(public element:ElementRef, @Inject(TooltipOptions) options:TooltipOptions) {
     Object.assign(this, options);
@@ -39,16 +39,22 @@ export class TooltipContainer {
     this.classMap[options.placement] = true;
   }
 
+  ngAfterViewChecked() {
+      if (this.hostEl !== null) {
+        let p = positionService
+        .positionElements(this.hostEl.nativeElement,
+            this.element.nativeElement.children[0],
+            this.placement, this.appendToBody);
+        this.top = p.top + 'px';
+        this.left = p.left + 'px';
+        this.classMap['in'] = true;
+      }
+  }
+
   public position(hostEl:ElementRef) {
     this.display = 'block';
-    this.top = '0px';
-    this.left = '0px';
-    let p = positionService
-      .positionElements(hostEl.nativeElement,
-        this.element.nativeElement.children[0],
-        this.placement, this.appendToBody);
-    this.top = p.top + 'px';
-    this.left = p.left + 'px';
-    this.classMap['in'] = true;
+    this.top = '-1000px';
+    this.left = '-1000px';
+    this.hostEl = hostEl;
   }
 }


### PR DESCRIPTION
This PR should fix the position of tooltips. 

Here is the explanation of the fix: to be able to position correctly the tooltip, the tooltip has to be "rendered" by angular and the browser (otherwise size of the tooltip is reported as (0,0). So when the left, top and display style are changed in the code, they are only effective after angular change detection takes them into account.

I also removed blanks before in the beginning of the template, they were causing issues sometimes (the tooltip on the "dynamic" word in the demo exhibit this issue).
