### PR TITLE
chore(package): angular2.0.0-beta.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
   },
   "homepage": "https://github.com/valor-software/ng2-bootstrap#readme",
   "dependencies": {
-    "angular2": "2.0.0-beta.8",
+    "angular2": "2.0.0-beta.9",
     "moment": "2.12.0"
   },
   "peerDependencies": {
-    "angular2": "2.0.0-beta.8"
+    "angular2": "2.0.0-beta.9"
   },
   "devDependencies": {
     "async": "1.5.2",


### PR DESCRIPTION
https://github.com/valor-software/ng2-bootstrap/issues/208

This may not `fix` #208 but it will help get past dependency issue to see what the issue is.
@valorkin You might bump and release with this latest dependency.

It may be nice to remove the `peerDependency` since things have (for most part) stabilized until final release. Having a locked `peerDependency` up until that point will likely continue to be a problem for people.
