### PR TITLE
Fix Typescript 7030 error in Carousel

### DIFF
--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -107,6 +107,7 @@ export class Carousel implements OnDestroy {
         return this.slides[i];
       }
     }
+    return null;
   }
 
   private getCurrentIndex() {


### PR DESCRIPTION
Typescript compiler throws error:

> TSError: ⨯ Unable to compile TypeScript
> node_modules/ng2-bootstrap/components/carousel/carousel.component.ts (103,11): Not all code paths return a value. (7030)

This pull request returns null in case no slide was found for the given index.
