### PR TITLE
fix(tooltip): Fixes #296 (Change detection errors in developer mode)

### DIFF
--- a/components/tooltip/tooltip-container.component.ts
+++ b/components/tooltip/tooltip-container.component.ts
@@ -49,7 +49,6 @@ export class TooltipContainer implements AfterViewInit {
     if (this.animation) {
       this.classMap.fade = true;
     }
-    // fix: why time out is really needed here?
-    setTimeout(() => this.cdr.markForCheck());
+    this.cdr.detectChanges();
   }
 }


### PR DESCRIPTION
I was still getting change detector errors on tooltips after commit 413c2f1 .
This change solved it for me, and as a bonus no timeout hack needed.
