### PR TITLE
fix(typeahead): Hide container with timeout to allow other events to propagate. Fixes #363

### DIFF
--- a/components/typeahead/typeahead.directive.ts
+++ b/components/typeahead/typeahead.directive.ts
@@ -102,7 +102,8 @@ export class Typeahead implements OnInit {
 
   @HostListener('blur', ['$event.target'])
   protected onBlur():void {
-    this.hide();
+    // Allow typeahead container click event to be triggered requires a timeout
+    setTimeout(this.hide.bind(this), 10);
   }
 
   @HostListener('keydown', ['$event'])


### PR DESCRIPTION
Fixes #363
