### PR TITLE
fix(Tabset): refactored tabs to avoid flicker

### DIFF
--- a/components/common.ts
+++ b/components/common.ts
@@ -28,3 +28,12 @@ export class NgTransclude {
     this.viewRef = _viewRef;
   }
 }
+
+export class Guid {
+  static newGuid() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+      return v.toString(16);
+    });
+  }
+}

--- a/components/tabs/tab.directive.ts
+++ b/components/tabs/tab.directive.ts
@@ -2,6 +2,7 @@ import {
   Directive, OnDestroy, Input, Output, HostBinding, TemplateRef, EventEmitter
 } from 'angular2/core';
 import {Tabset} from './tabset.component';
+import {Guid} from '../common';
 
 /* tslint:disable */
 @Directive({selector: 'tab, [tab]'})
@@ -34,20 +35,17 @@ export class Tab implements OnDestroy {
 
     this._active = active;
     this.select.emit(this);
-    this.tabset.tabs.forEach((tab:Tab) => {
-      if (tab !== this) {
-        tab.active = false;
-      }
-    });
   }
 
   @HostBinding('class.tab-pane') public addClass:boolean = true;
 
   public headingRef:TemplateRef;
   public tabset:Tabset;
+  public key: string;
   private _active:boolean;
 
   public constructor(tabset:Tabset) {
+    this.key = Guid.newGuid();
     this.tabset = tabset;
     this.tabset.addTab(this);
   }


### PR DESCRIPTION
I was experiencing some bad flicker, whereby adding a new tab would cause content from both the new tab and the previous tab to appear at the same time, until the `'active'` class had been removed from the old pane.

I believe the cause of the issue was due to the chained usage of `tab.active` to call `tab.active` on all the other tabs. Besides from solving the flicker issue, having `Tabset` coordinate the tabs via listening to tab events and then updating the other tabs makes more sense to me. ie. A tab should be aware of itself only, and the the tabset is aware of all tabs.
