### PR TITLE
fix(Collapse): Setting overflow back to visible on show

### DIFF
--- a/components/collapse/collapse.component.ts
+++ b/components/collapse/collapse.component.ts
@@ -120,6 +120,7 @@ export class Collapse implements OnInit {
           .onComplete(() => {
             this.isCollapse = true;
             this.isCollapsing = false;
+            this._el.nativeElement.style.overflow = 'visible';
           });
       }, 4);
   }


### PR DESCRIPTION
This fix helped me resolve 2 issues - collapse now expands all the way and takes component height  into consideration (issue #372), and also popups like datepicker aren't "cut-off" on component's edge.
