### PR TITLE
Not setting initDate results in current date being selected

### DIFF
--- a/components/datepicker/datepicker-inner.ts
+++ b/components/datepicker/datepicker-inner.ts
@@ -126,7 +126,7 @@ export class DatePickerInner implements OnInit {
 
     if (this.initDate) {
       this.activeDate = this.initDate;
-    } else {
+    } else if (this.activeDate === undefined) {
       this.activeDate = new Date();
     }
     this.selectedDate = new Date(this.activeDate.valueOf());


### PR DESCRIPTION
Before the inner datepicker sets the activeDate in ngOnInit it should check if it was already set.
Otherwise it overwrites the date set by ngModel.
