### PR TITLE
fix for #16: chore(datepicker): support null value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+<a name="1.0.14"></a>
+## [1.0.14](https://github.com/valor-software/ng2-bootstrap/compare/v1.0.13...v1.0.14) (2016-04-26)
+
+
+### Bug Fixes
+
+* **accordion:** Panel isn't resizing after content has changed ([914ae1a](https://github.com/valor-software/ng2-bootstrap/commit/914ae1a)), closes [#454](https://github.com/valor-software/ng2-bootstrap/issues/454)
+* **collapse:** Setting overflow back to visible in Collapse (#433) ([5c9434e](https://github.com/valor-software/ng2-bootstrap/commit/5c9434e)), closes [#372](https://github.com/valor-software/ng2-bootstrap/issues/372)
+* **datepicker:** If the date was set by ngModel it will be overwritten by default value ([6321253](https://github.com/valor-software/ng2-bootstrap/commit/6321253))
+
+### Features
+
+* **package:** updated angular2 to 0-beta.16 ([cec9e7b](https://github.com/valor-software/ng2-bootstrap/commit/cec9e7b))
+* **typeahead:** show list of options on focuse when minLength=0 ([f1c1909](https://github.com/valor-software/ng2-bootstrap/commit/f1c1909)), closes [#187](https://github.com/valor-software/ng2-bootstrap/issues/187) [#413](https://github.com/valor-software/ng2-bootstrap/issues/413)
+
+
+
 <a name="1.0.13"></a>
 ## [1.0.13](https://github.com/valor-software/ng2-bootstrap/compare/v1.0.12...v1.0.13) (2016-04-15)
 

--- a/components/datepicker/datepicker-inner.ts
+++ b/components/datepicker/datepicker-inner.ts
@@ -127,7 +127,7 @@ export class DatePickerInner implements OnInit {
     if (this.initDate) {
       this.activeDate = this.initDate;
       this.selectedDate = new Date(this.activeDate.valueOf());
-      this.update.emit(this.activeDate); //Only emit if selectedDate changed, otherwise datepicker already has correct value.
+      this.update.emit(this.activeDate); // Only emit if selectedDate changed, otherwise datepicker already has correct value.
     } else if (this.activeDate === undefined) {
       this.activeDate = new Date();
     }
@@ -150,7 +150,7 @@ export class DatePickerInner implements OnInit {
   }
 
   public compare(date1:Date, date2:Date):number {
-    if(date1=== undefined || date2 === undefined){
+    if(date1 === undefined || date2 === undefined) {
       return undefined;
     }
 

--- a/components/datepicker/datepicker-inner.ts
+++ b/components/datepicker/datepicker-inner.ts
@@ -126,12 +126,12 @@ export class DatePickerInner implements OnInit {
 
     if (this.initDate) {
       this.activeDate = this.initDate;
+      this.selectedDate = new Date(this.activeDate.valueOf());
+      this.update.emit(this.activeDate); //Only emit if selectedDate changed, otherwise datepicker already has correct value.
     } else if (this.activeDate === undefined) {
       this.activeDate = new Date();
     }
-    this.selectedDate = new Date(this.activeDate.valueOf());
 
-    this.update.emit(this.activeDate);
     this.refreshView();
   }
 
@@ -150,6 +150,10 @@ export class DatePickerInner implements OnInit {
   }
 
   public compare(date1:Date, date2:Date):number {
+    if(date1=== undefined || date2 === undefined){
+      return undefined;
+    }
+
     if (this.datepickerMode === 'day' && this.compareHandlerDay) {
       return this.compareHandlerDay(date1, date2);
     }

--- a/components/datepicker/datepicker.ts
+++ b/components/datepicker/datepicker.ts
@@ -73,7 +73,7 @@ export class DatePicker implements ControlValueAccessor {
 
   @Input()
   public get activeDate():Date {
-    return this._activeDate || this._now;
+    return this._activeDate;
   }
 
   public constructor(@Self() cd:NgModel) {

--- a/components/datepicker/datepicker.ts
+++ b/components/datepicker/datepicker.ts
@@ -73,7 +73,7 @@ export class DatePicker implements ControlValueAccessor {
 
   @Input()
   public get activeDate():Date {
-    return this._activeDate;
+    return this._activeDate || this._now;
   }
 
   public constructor(@Self() cd:NgModel) {

--- a/components/tooltip/tooltip.directive.ts
+++ b/components/tooltip/tooltip.directive.ts
@@ -1,6 +1,6 @@
 import {
-  Directive, Input, HostListener, ElementRef, DynamicComponentLoader,
-  ComponentRef, Provider, Injector
+  Directive, Input, HostListener, DynamicComponentLoader,
+  ComponentRef, Provider, ReflectiveInjector, ViewContainerRef
 } from 'angular2/core';
 import {TooltipOptions} from './tooltip-options.class';
 import {TooltipContainer} from './tooltip-container.component';
@@ -16,14 +16,14 @@ export class Tooltip {
   @Input('tooltipAppendToBody') public appendToBody:boolean;
   /* tslint:enable */
 
-  public element:ElementRef;
+  public viewContainerRef:ViewContainerRef;
   public loader:DynamicComponentLoader;
 
   private visible:boolean = false;
   private tooltip:Promise<ComponentRef>;
 
-  public constructor(element:ElementRef, loader:DynamicComponentLoader) {
-    this.element = element;
+  public constructor(viewContainerRef:ViewContainerRef, loader:DynamicComponentLoader) {
+    this.viewContainerRef = viewContainerRef;
     this.loader = loader;
   }
 
@@ -40,15 +40,15 @@ export class Tooltip {
       content: this.content,
       placement: this.placement,
       animation: this.animation,
-      hostEl: this.element
+      hostEl: this.viewContainerRef
     });
 
-    let binding = Injector.resolve([
+    let binding = ReflectiveInjector.resolve([
       new Provider(TooltipOptions, {useValue: options})
     ]);
 
     this.tooltip = this.loader
-      .loadNextToLocation(TooltipContainer, this.element, binding)
+      .loadNextToLocation(TooltipContainer, this.viewContainerRef, binding)
       .then((componentRef:ComponentRef) => {
         return componentRef;
       });
@@ -63,7 +63,7 @@ export class Tooltip {
     }
     this.visible = false;
     this.tooltip.then((componentRef:ComponentRef) => {
-      componentRef.dispose();
+      componentRef.destroy();
       return componentRef;
     });
   }

--- a/package.json
+++ b/package.json
@@ -47,20 +47,20 @@
   },
   "homepage": "https://github.com/valor-software/ng2-bootstrap#readme",
   "dependencies": {
-    "angular2": "2.0.0-beta.15",
     "moment": "2.13.0"
   },
   "peerDependencies": {
-    "angular2": "2.0.0-beta.15"
+    "angular2": "2.0.0-beta.16"
   },
   "devDependencies": {
+    "angular2": "2.0.0-beta.16",
     "async": "1.5.2",
     "balanced-match": "0.4.0",
     "bootstrap": "3.3.6",
     "compression-webpack-plugin": "0.3.1",
     "conventional-changelog-cli": "1.1.1",
     "conventional-github-releaser": "1.1.2",
-    "copy-webpack-plugin": "2.1.1",
+    "copy-webpack-plugin": "2.1.3",
     "cpy-cli": "1.0.0",
     "del-cli": "0.2.0",
     "es6-promise": "3.1.2",
@@ -100,7 +100,7 @@
     "source-map-loader": "0.1.5",
     "systemjs-builder": "0.15.15",
     "ts-loader": "0.8.2",
-    "tslint-config-valorsoft": "0.0.7",
+    "tslint-config-valorsoft": "1.0.1",
     "typescript": "1.8.10",
     "typings": "0.8.1",
     "webpack": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-bootstrap",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "angular2 bootstrap components",
   "scripts": {
     "flow.install:typings": "./node_modules/.bin/typings install",


### PR DESCRIPTION
Introduced support for null as default value:
- In the ngOnInit method of the datepicker-inner class the update should only emit when selectedDate is changed.
- Extra check in compare function
- activeDate() shouldn't return today when not set
