### PR TITLE
fix(tooltip): Fix tooltip arrows in bootstrap v4

### DIFF
--- a/components/tooltip/tooltip-container.component.ts
+++ b/components/tooltip/tooltip-container.component.ts
@@ -44,6 +44,7 @@ export class TooltipContainer implements AfterViewInit {
     Object.assign(this, options);
     this.classMap = {'in': false, 'fade': false};
     this.classMap[options.placement] = true;
+    this.classMap['tooltip-' + options.placement] = true;
   }
 
   public ngAfterViewInit():void {


### PR DESCRIPTION
I wondered why the tooltip arrows didn't work in v4. After some digging i found that the CSS in v4 is somewhat tied to the classes that tether.js applies. But i also found that bootstrap v4, provides the same functionality by simply adding tooltip-<placement> as a class.

The additional class is only needed in v4. 
Do you have a way that you use for checking wether we are running v3 or v4 bootstrap?
Or do you have an idea of how to only apply the class when using bootstrap 4?
