### PR TITLE
Remove 'z' in slide name

### DIFF
--- a/demo/components/carousel/carousel-demo.html
+++ b/demo/components/carousel/carousel-demo.html
@@ -1,14 +1,14 @@
 <div class="row">
   <div class="col-md-6">
     <carousel [interval]="myInterval" [noWrap]="noWrapSlides">
-      <slide *ngFor="let slidez of slides; let index=index"
-             [active]="slidez.active">
-        <img [src]="slidez.image" style="margin:auto;">
+      <slide *ngFor="let slide of slides; let index=index"
+             [active]="slide.active">
+        <img [src]="slide.image" style="margin:auto;">
 
         <div class="carousel-caption">
           <h4>Slide {{index}}</h4>
 
-          <p>{{slidez.text}}</p>
+          <p>{{slide.text}}</p>
         </div>
       </slide>
     </carousel>


### PR DESCRIPTION
Looks like is a typo or confusing demo wrong naming on 'slide' called 'slidez'.
