### PR TITLE
typeahead: removed incorrect behavior on TAB

### DIFF
--- a/components/typeahead/typeahead.directive.ts
+++ b/components/typeahead/typeahead.directive.ts
@@ -143,15 +143,9 @@ export class TypeaheadDirective implements OnInit {
       return;
     }
 
-    // if shift + tab, close items list
-    if (e.shiftKey && e.keyCode === 9) {
+    // if tab default browser behavior will select next input field, and therefore we should close the items list
+    if (e.keyCode === 9) {
       this.hide();
-      return;
-    }
-
-    // if tab select current item
-    if (!e.shiftKey && e.keyCode === 9) {
-      this.container.selectActiveMatch();
       return;
     }
   }


### PR DESCRIPTION
TAB should simply skip to next field as expected. Solves #686 and #490
