### PR TITLE
Emitting event when datepicker selection is done

### DIFF
--- a/components/datepicker/datepicker-inner.component.ts
+++ b/components/datepicker/datepicker-inner.component.ts
@@ -70,7 +70,7 @@ export class DatePickerInnerComponent implements OnInit, OnChanges {
   @Input() public dateDisabled:any;
   @Input() public initDate:Date;
 
-  @Output() public selectionDone: EventEmitter<Date> = new EventEmitter<Date>(null);
+  @Output() public selectionDone: EventEmitter<Date> = new EventEmitter<Date>(undefined);
 
   public stepDay:any = {};
   public stepMonth:any = {};

--- a/components/datepicker/datepicker-inner.component.ts
+++ b/components/datepicker/datepicker-inner.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, EventEmitter, Input, OnChanges} from '@angular/core';
+import {Component, OnInit, EventEmitter, Input, OnChanges, Output} from '@angular/core';
 import {CORE_DIRECTIVES, NgClass} from '@angular/common';
 import {FORM_DIRECTIVES, NgModel} from '@angular/forms';
 import {DateFormatter} from './date-formatter';
@@ -69,6 +69,8 @@ export class DatePickerInnerComponent implements OnInit, OnChanges {
   // todo: change type during implementation
   @Input() public dateDisabled:any;
   @Input() public initDate:Date;
+
+  @Output() public selectionDone: EventEmitter<Date> = new EventEmitter<Date>(null);
 
   public stepDay:any = {};
   public stepMonth:any = {};
@@ -248,6 +250,7 @@ export class DatePickerInnerComponent implements OnInit, OnChanges {
       }
 
       this.activeDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+      this.selectionDone.emit(this.activeDate);
     } else {
       this.activeDate = date;
       this.datepickerMode = this.modes[this.modes.indexOf(this.datepickerMode) - 1];

--- a/components/datepicker/datepicker.component.ts
+++ b/components/datepicker/datepicker.component.ts
@@ -65,7 +65,7 @@ export class DatePickerComponent implements ControlValueAccessor {
 // todo: change type during implementation
   @Input() public dateDisabled:any;
 
-  @Output() public selectionDone: EventEmitter<Date> = new EventEmitter<Date>(null);
+  @Output() public selectionDone: EventEmitter<Date> = new EventEmitter<Date>(undefined);
 
   public onChange:any = Function.prototype;
   public onTouched:any = Function.prototype;
@@ -94,7 +94,7 @@ export class DatePickerComponent implements ControlValueAccessor {
     this.cd.viewToModelUpdate(event);
   }
 
-  public onSelectionDone(event: Date) {
+  public onSelectionDone(event: Date): void {
     this.selectionDone.emit(event);
   }
 

--- a/components/datepicker/datepicker.component.ts
+++ b/components/datepicker/datepicker.component.ts
@@ -1,4 +1,4 @@
-import {Component, Self, Input} from '@angular/core';
+import {Component, Self, Input, Output, EventEmitter} from '@angular/core';
 import {CORE_DIRECTIVES} from '@angular/common';
 import {FORM_DIRECTIVES, ControlValueAccessor, NgModel} from '@angular/forms';
 import {DatePickerInnerComponent} from './datepicker-inner.component';
@@ -32,7 +32,8 @@ import {YearPickerComponent} from './yearpicker.component';
                       [dateDisabled]="dateDisabled"
                       [templateUrl]="templateUrl"
                       [onlyCurrentMonth]="onlyCurrentMonth"
-                      [shortcutPropagation]="shortcutPropagation">
+                      [shortcutPropagation]="shortcutPropagation"
+                      (selectionDone)="onSelectionDone($event)">
       <daypicker tabindex="0"></daypicker>
       <monthpicker tabindex="0"></monthpicker>
       <yearpicker tabindex="0"></yearpicker>
@@ -64,6 +65,8 @@ export class DatePickerComponent implements ControlValueAccessor {
 // todo: change type during implementation
   @Input() public dateDisabled:any;
 
+  @Output() public selectionDone: EventEmitter<Date> = new EventEmitter<Date>(null);
+
   public onChange:any = Function.prototype;
   public onTouched:any = Function.prototype;
 
@@ -89,6 +92,10 @@ export class DatePickerComponent implements ControlValueAccessor {
   public onUpdate(event:any):void {
     this.writeValue(event);
     this.cd.viewToModelUpdate(event);
+  }
+
+  public onSelectionDone(event: Date) {
+    this.selectionDone.emit(event);
   }
 
   // todo: support null value


### PR DESCRIPTION
Hi @valorkin,

In my project I need to have datepicker 'popup' functionality ASAP. I decided to add an event to datepicker which fires when date selection is done (picker reached minMode). Additionally, I don't want to use ngModel two way binding since it changes model value event when selection is not yet done (I want to select month, but I'm on a year view - clicking year changes model which is unacceptable for me). In this PR, I use selectionDone event to both receive selected date and as a signal to close datepicker popup.

This can be useful in #273 
