### PR TITLE
Feature: tooltip html content as template

### DIFF
--- a/components/tooltip/readme.md
+++ b/components/tooltip/readme.md
@@ -17,6 +17,7 @@ export class TooltipDirective {
   @Input('tooltipEnable') private enable:boolean;
   @Input('tooltipAppendToBody') private appendToBody:boolean;
   @Input('tooltipClass') public popupClass:string;
+  @Input('tooltipContext') public tooltipContext:any;
 }
 ```
 
@@ -31,3 +32,4 @@ export class TooltipDirective {
   - `tooltipAppendToBody` (*not implemented*) (`?boolean=false`) - if `true` tooltip will be appended to body
   - `tooltipClass` (`?string`) - custom tooltip class applied to the tooltip container
   - `tooltipIsOpen` (`?boolean=false`) - if `true` tooltip is currently visible
+  - `tooltipContext` (`any`) - if a template is used for the content, then this property can be used to specify a context for that template. The template variable exposed is called 'model'.

--- a/components/tooltip/readme.md
+++ b/components/tooltip/readme.md
@@ -11,6 +11,7 @@ import { TOOLTIP_DIRECTIVES } from 'ng2-bootstrap/components/tooltip';
 @Directive({ selector: '[tooltip]' })
 export class TooltipDirective {
   @Input('tooltip') private content:string;
+  @Input('tooltipHtml') public htmlContent:string | TemplateRef<any>;
   @Input('tooltipPlacement') private placement:string = 'top';
   @Input('tooltipIsOpen') private isOpen:boolean;
   @Input('tooltipEnable') private enable:boolean;
@@ -21,6 +22,7 @@ export class TooltipDirective {
 
 ### Tooltip properties
   - `tooltip` (`string`) - text of tooltip
+  - `tooltipHtml` (`string|TempalteRef`) - tooltip custom html content, defined as string or template reference
   - `tooltipPlacement` (`?string='top'`) - tooltip positioning instruction, supported positions: 'top', 'bottom', 'left', 'right'
   - `tooltipAnimation` (`?boolean=true`) - if `false` fade tooltip animation will be disabled
   - `tooltipPopupDelay` (*not implemented*) (`?numer=0`) - time in milliseconds before tooltip occurs

--- a/components/tooltip/tooltip-container.component.ts
+++ b/components/tooltip/tooltip-container.component.ts
@@ -19,7 +19,8 @@ import {TooltipOptions} from './tooltip-options.class';
       </div>
       <div class="tooltip-inner"
            *ngIf="htmlContent && isTemplate">
-        <template [ngTemplateOutlet]="htmlContent">
+        <template [ngTemplateOutlet]="htmlContent"
+                  [ngOutletContext]="{model: context}">
         </template>
       </div>
       <div class="tooltip-inner"
@@ -42,6 +43,7 @@ export class TooltipContainerComponent implements AfterViewInit {
   private isOpen:boolean;
   private appendToBody:boolean;
   private hostEl:ElementRef;
+  private context:any;
   /* tslint:enable */
 
   private element:ElementRef;
@@ -78,7 +80,7 @@ export class TooltipContainerComponent implements AfterViewInit {
     this.cdr.detectChanges();
   }
 
-  get isTemplate() {
+  public get isTemplate():boolean {
     return this.htmlContent instanceof TemplateRef;
   }
 }

--- a/components/tooltip/tooltip-container.component.ts
+++ b/components/tooltip/tooltip-container.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, ChangeDetectorRef, ElementRef, Inject, AfterViewInit
+  Component, ChangeDetectorRef, ElementRef, Inject, AfterViewInit, TemplateRef
 } from '@angular/core';
 import {NgClass, NgStyle} from '@angular/common';
 import {positionService} from '../position';
@@ -14,8 +14,13 @@ import {TooltipOptions} from './tooltip-options.class';
      [ngClass]="classMap">
       <div class="tooltip-arrow"></div>
       <div class="tooltip-inner"
-           *ngIf="htmlContent" 
+           *ngIf="htmlContent && !isTemplate" 
            innerHtml="{{htmlContent}}">
+      </div>
+      <div class="tooltip-inner"
+           *ngIf="htmlContent && isTemplate">
+        <template [ngTemplateOutlet]="htmlContent">
+        </template>
       </div>
       <div class="tooltip-inner"
            *ngIf="content">
@@ -30,7 +35,7 @@ export class TooltipContainerComponent implements AfterViewInit {
   private left:string = '-1000px';
   private display:string = 'block';
   private content:string;
-  private htmlContent:string;
+  private htmlContent:string | TemplateRef<any>;
   private placement:string;
   private popupClass:string;
   private animation:boolean;
@@ -71,5 +76,9 @@ export class TooltipContainerComponent implements AfterViewInit {
     }
 
     this.cdr.detectChanges();
+  }
+
+  get isTemplate() {
+    return this.htmlContent instanceof TemplateRef;
   }
 }

--- a/components/tooltip/tooltip-options.class.ts
+++ b/components/tooltip/tooltip-options.class.ts
@@ -8,6 +8,7 @@ export class TooltipOptions {
   public isOpen:boolean;
   public content:string;
   public htmlContent:any;
+  public context:any;
 
   public constructor(options:Object) {
     Object.assign(this, options);

--- a/components/tooltip/tooltip-options.class.ts
+++ b/components/tooltip/tooltip-options.class.ts
@@ -7,7 +7,7 @@ export class TooltipOptions {
   public animation:boolean;
   public isOpen:boolean;
   public content:string;
-  public htmlContent:string;
+  public htmlContent:any;
 
   public constructor(options:Object) {
     Object.assign(this, options);

--- a/components/tooltip/tooltip.directive.ts
+++ b/components/tooltip/tooltip.directive.ts
@@ -1,6 +1,6 @@
 import {
   Directive, Input, HostListener, DynamicComponentLoader,
-  ComponentRef, Provider, ReflectiveInjector, ViewContainerRef
+  ComponentRef, Provider, ReflectiveInjector, ViewContainerRef, TemplateRef
 } from '@angular/core';
 import {TooltipOptions} from './tooltip-options.class';
 import {TooltipContainerComponent} from './tooltip-container.component';
@@ -11,7 +11,7 @@ import {TooltipContainerComponent} from './tooltip-container.component';
 export class TooltipDirective {
   /* tslint:disable */
   @Input('tooltip') public content:string;
-  @Input('tooltipHtml') public htmlContent:string;
+  @Input('tooltipHtml') public htmlContent:string | TemplateRef<any>;
   @Input('tooltipPlacement') public placement:string = 'top';
   @Input('tooltipIsOpen') public isOpen:boolean;
   @Input('tooltipEnable') public enable:boolean = true;

--- a/components/tooltip/tooltip.directive.ts
+++ b/components/tooltip/tooltip.directive.ts
@@ -18,6 +18,7 @@ export class TooltipDirective {
   @Input('tooltipAnimation') public animation:boolean = true;
   @Input('tooltipAppendToBody') public appendToBody:boolean;
   @Input('tooltipClass') public popupClass:string;
+  @Input('tooltipContext') public tooltipContext:any;
   /* tslint:enable */
 
   public viewContainerRef:ViewContainerRef;
@@ -46,7 +47,8 @@ export class TooltipDirective {
       placement: this.placement,
       animation: this.animation,
       hostEl: this.viewContainerRef.element,
-      popupClass: this.popupClass
+      popupClass: this.popupClass,
+      context: this.tooltipContext
     });
 
     let binding = ReflectiveInjector.resolve([

--- a/demo/components/tooltip/tooltip-demo.html
+++ b/demo/components/tooltip/tooltip-demo.html
@@ -26,6 +26,15 @@
   I can even contain HTML. <a href="#" [tooltipHtml]="htmlTooltip">Check me out!</a>
 </p>
 
+<template #toolTipTemplate>
+  <h3>Tool tip custom content</h3>
+  <h4>defined inside a template</h4>
+</template>
+
+<p>
+  Or use a TemplateRef. <a href="#" [tooltipHtml]="toolTipTemplate">Check me out!</a>
+<p>
+
 <p>
   I can have a custom class. <a href="#" tooltip="I can have a custom class applied to me!" tooltipClass="customClass">Check me out!</a>
 </p>

--- a/demo/components/tooltip/tooltip-demo.html
+++ b/demo/components/tooltip/tooltip-demo.html
@@ -26,13 +26,13 @@
   I can even contain HTML. <a href="#" [tooltipHtml]="htmlTooltip">Check me out!</a>
 </p>
 
-<template #toolTipTemplate>
-  <h3>Tool tip custom content</h3>
-  <h4>defined inside a template</h4>
+<template #toolTipTemplate let-model="model">
+  <h4>Tool tip custom content defined inside a template</h4>
+  <h5>With context binding: {{model.text}}</h5>
 </template>
 
 <p>
-  Or use a TemplateRef. <a href="#" [tooltipHtml]="toolTipTemplate">Check me out!</a>
+  Or use a TemplateRef. <a href="#" [tooltipHtml]="toolTipTemplate" [tooltipContext]="tooltipModel">Check me out!</a>
 <p>
 
 <p>

--- a/demo/components/tooltip/tooltip-demo.ts
+++ b/demo/components/tooltip/tooltip-demo.ts
@@ -16,4 +16,5 @@ export class TooltipDemoComponent {
   public dynamicTooltip:string = 'Hello, World!';
   public dynamicTooltipText:string = 'dynamic';
   public htmlTooltip:string = 'I\'ve been made <b>bold</b>!';
+  public tooltipModel:any = { text: 'foo', index: 1 };
 }


### PR DESCRIPTION
Added option to define the html content of a tooltip using a [TemplateRef](https://angular.io/docs/ts/latest/api/core/index/TemplateRef-class.html), with context, using [NgTemplateOutlet](https://angular.io/docs/ts/latest/api/common/index/NgTemplateOutlet-directive.html).
