### PR TITLE
directives, inputs and properties are deprecated for the component annotation and zone.js update

### DIFF
--- a/components/collapse/collapse.directive.spec.ts
+++ b/components/collapse/collapse.directive.spec.ts
@@ -54,7 +54,9 @@ describe('Directive: Collapse', () => {
     expect(element.offsetHeight).toBe(0);
   });
 
-  xit('should not trigger any animation on initialization if isCollapsed = true');
+  xit('should not trigger any animation on initialization if isCollapsed = true', () => {
+    expect(true);
+  });
 
   it('should collapse if isCollapsed = true on subsequent use', () => {
     context.isCollapsed = false;
@@ -73,7 +75,9 @@ describe('Directive: Collapse', () => {
     expect(element.offsetHeight).not.toBe(0);
   });
 
-  xit('should not trigger any animation on initialization if isCollapsed = false');
+  xit('should not trigger any animation on initialization if isCollapsed = false', () => {
+    expect(true);
+  });
 
   it('should expand if isCollapsed = false on subsequent use', () => {
     context.isCollapsed = false;
@@ -136,12 +140,22 @@ describe('Directive: Collapse', () => {
   });
 
   describe('expanding callback returning a promise', () => {
-    xit('should wait for it to resolve before animating');
-    xit('should not animate if it rejects');
+    xit('should wait for it to resolve before animating', () => {
+      expect(true);
+    });
+
+    xit('should not animate if it rejects', () => {
+      expect(true);
+    });
   });
 
   describe('collapsing callback returning a promise', () => {
-    xit('should wait for it to resolve before animating');
-    xit('should not animate if it rejects');
+    xit('should wait for it to resolve before animating', () => {
+      expect(true);
+    });
+
+    xit('should not animate if it rejects', () => {
+      expect(true);
+    });
   });
 });

--- a/components/common.ts
+++ b/components/common.ts
@@ -1,18 +1,20 @@
-import {Directive, Inject, TemplateRef, ViewContainerRef} from '@angular/core';
+import {
+  Directive, Inject, Input, TemplateRef, ViewContainerRef
+} from '@angular/core';
 
 export interface KeyAttribute {
   [key: string]: any;
 }
 
 @Directive({
-  selector: '[ngTransclude]',
-  properties: ['ngTransclude']
+  selector: '[ngTransclude]'
 })
 export class NgTranscludeDirective {
   public viewRef: ViewContainerRef;
 
   private _ngTransclude: TemplateRef<any>;
 
+  @Input()
   private set ngTransclude(templateRef: TemplateRef<any>) {
     this._ngTransclude = templateRef;
     if (templateRef) {

--- a/components/datepicker/datepicker-popup.component.ts
+++ b/components/datepicker/datepicker-popup.component.ts
@@ -1,13 +1,11 @@
-import {CORE_DIRECTIVES, NgClass, NgStyle} from '@angular/common';
 import {
-  Component, ComponentRef, Directive, ElementRef, EventEmitter, Output,
+  Component, ComponentRef, Directive, ElementRef, EventEmitter, Input, Output,
   ReflectiveInjector, Renderer, Self, ViewContainerRef, ViewEncapsulation
 } from '@angular/core';
-import {FORM_DIRECTIVES, NgModel} from '@angular/forms';
+import {NgModel} from '@angular/forms';
 
 import {KeyAttribute} from '../common';
 import {positionService} from '../position';
-import {DatePickerComponent} from './datepicker.component';
 import { ComponentsHelper } from '../utils/components-helper.service';
 
 // import {DatePickerInner} from './datepicker-inner';
@@ -53,7 +51,6 @@ const datePickerPopupConfig:KeyAttribute = {
             <button type="button" class="btn btn-sm btn-success pull-right" (click)="close()">{{ getText('close') }}</button>
         </li>
     </ul>`,
-  directives: [NgClass, NgStyle, DatePickerComponent, FORM_DIRECTIVES, CORE_DIRECTIVES],
   encapsulation: ViewEncapsulation.None
 })
 class PopupContainerComponent {
@@ -115,10 +112,9 @@ class PopupContainerComponent {
 }
 
 @Directive({
-  selector: '[datepickerPopup][ngModel]',
+  selector: '[datepickerPopup][ngModel]'/*,
   // prop -> datepickerPopup - format
-  properties: ['datepickerPopup', 'isOpen']/*,
-   host: {'(cupdate)': 'onUpdate1($event)'}*/
+  host: {'(cupdate)': 'onUpdate1($event)'}*/
 })
 export class DatePickerPopupDirective {
   public cd:NgModel;
@@ -152,6 +148,7 @@ export class DatePickerPopupDirective {
     return this._isOpen;
   }
 
+  @Input()
   private set isOpen(value:boolean) {
     let fn = () => {
       this._isOpen = value;

--- a/package.json
+++ b/package.json
@@ -90,12 +90,12 @@
     "pre-commit": "1.1.3",
     "reflect-metadata": "0.1.8",
     "require-dir": "0.3.0",
-    "rxjs": "5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.11",
     "systemjs-builder": "0.15.29",
     "tslint-config-valorsoft": "1.1.1",
     "typedoc": "0.4.5",
     "typescript": "1.8.10",
     "typings": "1.3.2",
-    "zone.js": "0.6.12"
+    "zone.js": "0.6.17"
   }
 }

--- a/spec-bundle.js
+++ b/spec-bundle.js
@@ -22,10 +22,11 @@ require('ts-helpers');
 
 require('zone.js/dist/zone');
 require('zone.js/dist/long-stack-trace-zone');
-require('zone.js/dist/jasmine-patch');
 require('zone.js/dist/async-test');
 require('zone.js/dist/fake-async-test');
 require('zone.js/dist/sync-test');
+require('zone.js/dist/proxy');
+require('zone.js/dist/jasmine-patch');
 
 // RxJS
 require('rxjs/Rx');


### PR DESCRIPTION
directives, inputs and properties are deprecated for the component annotation and update rxjs (5.0.0-beta.6 -> 5.0.0-beta.11) and zone.js (0.6.12 -> 0.6.17) dependencies and make updated zone.js work (see angular/zone.js#404)
