### PR TITLE
fix(doc): Drop now-useless BS_VIEW_PROVIDERS instructions

### DIFF
--- a/components/modal/title.md
+++ b/components/modal/title.md
@@ -2,9 +2,6 @@ Modals are streamlined, but flexible, dialog prompts with the minimum required f
 
 Base specifications: [bootstrap 3](http://getbootstrap.com/javascript/#modals) or [bootstrap 4](http://v4-alpha.getbootstrap.com/components/modal/)
 
-### **Important notes**:
-- Don't forget to add view provider
-
 ```typescript
 import {ModalModule} from 'ng2-bootstrap/ng2-bootstrap';
 
@@ -18,8 +15,6 @@ import {ModalModule} from 'ng2-bootstrap/ng2-bootstrap';
 })
 
 ```
-
-- Don't forget to add `hack` to your application root component ([why?](https://github.com/angular/angular/issues/6446#issuecomment-173459525))
 
 ```typescript
 import {Component, ViewContainerRef} from '@angular/core';


### PR DESCRIPTION
With the change to Angular RC5, `viewProviders` do not need to be added to components anymore. Therefore, the instruction saying "Don't forget to add view provider" are just confusing and need to be removed.
