### PR TITLE
Fixed undefined event in Collapse directive

### DIFF
--- a/components/collapse/collapse.directive.ts
+++ b/components/collapse/collapse.directive.ts
@@ -97,7 +97,7 @@ export class CollapseDirective implements OnInit {
     this.isCollapsing = false;
 
     this.display = 'none';
-    this.collapsed.emit(event);
+    this.collapsed.emit(this.isExpanded);
 
     /*  setTimeout(() => {
      // this.height = '0';
@@ -137,7 +137,7 @@ export class CollapseDirective implements OnInit {
     this.isCollapsing = false;
     this._renderer.setElementStyle(this._el.nativeElement, 'overflow', 'visible');
     this._renderer.setElementStyle(this._el.nativeElement, 'height', 'auto');
-    this.expanded.emit(event);
+    this.expanded.emit(this.isExpanded);
     /*setTimeout(() => {
      // this.height = 'auto';
      // this.isCollapse = true;


### PR DESCRIPTION
There was an undefined event in collapse directive making it crash on Firefox.
Small change to use the state (isExpanded) for this. Should be merged with #864 
