### PR TITLE
chore: update all BS references to 3.3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Follow me [![twitter](https://img.shields.io/twitter/follow/valorkin.svg?style=s
 *Hint*: simpliest way to add styles is a CDN:
 ```html
 <!-- index.html -->
-<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
 ```
 
 ### With system.js: [angular2-quickstart](https://github.com/valor-software/angular2-quickstart)
@@ -90,7 +90,7 @@ npm i ng2-bootstrap --save
 Check [cdnjs](https://cdnjs.com/libraries/ng2-bootstrap) to include `ng2-bootstrap` as `system.js` bundle
 ```html
 <script src="https://cdnjs.cloudflare.com/ajax/libs/ng2-bootstrap/x.x.x/ng2-bootstrap.min.js"></script>
-<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
 ```
 
 ## Quick start
@@ -101,7 +101,7 @@ If you are following [Angular2 5 min quickstart guide](https://angular.io/docs/t
 ```html
 <!-- index.html -->
 <script src="node_modules/ng2-bootstrap/bundles/ng2-bootstrap.min.js"></script>
-<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
 ```
 
 As for now `datepicker` is using `moment.js` to format date, so please update `system.js` config to contain mapping:

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,7 +16,7 @@
   <!--<link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">-->
 
   <!--link to bootstrap.css-->
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/prettify-angulario.css">
 </head>


### PR DESCRIPTION
This commit updates all references of BS 3.0 from
3.3.\* to 3.3.7 - as 3.3.7 was introduced in #783 PR
but no references in content have been updated.

Someone should look into demo application and quickly check how it renders under 3.3.7 (I've done this, but I haven't used the project in production, so have no experience with default design).

Thanks!
