### PR TITLE
Remove moment, replace with angular2 DatePipe.  And Date.parse in demo.

### DIFF
--- a/.config/bundle-system.js
+++ b/.config/bundle-system.js
@@ -59,7 +59,6 @@ function getSystemJsBundleConfig(cb) {
     memo[path.resolve(`node_modules/${currentValue}/*`)] = {build: false};
     return memo;
   }, {});
-  config.meta.moment = {build: false};
   return cb(null, config);
 }
 

--- a/README.md
+++ b/README.md
@@ -104,22 +104,6 @@ If you are following [Angular2 5 min quickstart guide](https://angular.io/docs/t
 <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
 ```
 
-As for now `datepicker` is using `moment.js` to format date, so please update `system.js` config to contain mapping:
-```html
-<!-- index.html -->
-  System.config({
-    packages: {
-      app: {
-        format: 'register',
-        defaultExtension: 'js'
-      }
-    },
-    map: {
-      moment: 'node_modules/moment/moment.js'
-    }
-  });
-```
-
 Add Ng2BootstrapModule as imported module in your application module `app.module.ts`
 
 ```ts

--- a/components/datepicker/date-formatter.ts
+++ b/components/datepicker/date-formatter.ts
@@ -1,7 +1,9 @@
-import * as moment from 'moment';
+import { DatePipe } from '@angular/common';
+
+const dp = new DatePipe('en-US');
 
 export class DateFormatter {
   public format(date:Date, format:string):string {
-    return moment(date.getTime()).format(format);
+    return dp.transform(date, format);
   }
 }

--- a/demo/components/datepicker/datepicker-demo.ts
+++ b/demo/components/datepicker/datepicker-demo.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import * as moment from 'moment';
 
 // webpack html imports
 let template = require('./datepicker-demo.html');
@@ -41,7 +40,7 @@ export class DatepickerDemoComponent {
   }
 
   public d20090824():void {
-    this.dt = moment('2009-08-24', 'YYYY-MM-DD').toDate();
+    this.dt = new Date('Aug 24, 2009');
   }
 
   // todo: implement custom class cases

--- a/demo/components/getting-started/dependencies.md
+++ b/demo/components/getting-started/dependencies.md
@@ -15,8 +15,6 @@ This module works with bootstrap 3 and 4
 ### Dependencies
 This module consists of native Angular2 components and directives, no jQuery or Bootstrap javascript is required.
 
-**NOTE**: `datepicker` requires moment for data parsing, until Intl polyfill will be implemented
-
 Always actual list of JS dependencies you can find [here](https://david-dm.org/valor-software/ng2-bootstrap)
 
 This module plays nice with Bootstrap CSS [v3](http://getbootstrap.com/css/) and [v4](http://v4-alpha.getbootstrap.com)

--- a/demo/components/getting-started/installation.md
+++ b/demo/components/getting-started/installation.md
@@ -6,17 +6,6 @@
 npm install --save ng2-bootstrap
 ```
 
-Additionally you will need `moment.js` typings if you are planning to work with datepicker
-
-```bash
-# install typings globally
-npm install -g typings
-# init typings if you don't have typings.json yet
-typings init
-# and install moment.js typings
-typings install moment --save
-```
-
 ### How to use it with webpack?
 
 Please refer to [readme](https://github.com/valor-software/ng2-bootstrap#with-webpack-angularclassangular2-webpack-starter)

--- a/demo/getting-started.md
+++ b/demo/getting-started.md
@@ -3,8 +3,6 @@
 ### Dependencies
 This module consists of native Angular2 components and directives, no jQuery or Bootstrap javascript is required.
 
-*datepicker*: requires moment for data parsing, until Intl polyfill will be implemented
-
 Always actual list of JS dependencies you can find [here](https://david-dm.org/valor-software/ng2-bootstrap)
 
 Plus this module plays nice with Bootstrap CSS [v3](http://getbootstrap.com/css/) and [v4](http://v4-alpha.getbootstrap.com)

--- a/package.json
+++ b/package.json
@@ -49,9 +49,6 @@
     "url": "https://github.com/valor-software/ng2-bootstrap/issues"
   },
   "homepage": "https://github.com/valor-software/ng2-bootstrap#readme",
-  "dependencies": {
-    "moment": "2.14.1"
-  },
   "peerDependencies": {
     "@angular/common": "2.0.0-rc.6",
     "@angular/compiler": "2.0.0-rc.6",


### PR DESCRIPTION
It has always been the intention to phase out moment, there is an alternative which is angular2's DatePipe which is always available as this is an angular2 library.  I figured we might as well use it so we can ditch the moment dependency.

In this commit I also removed moment from the docs and demo.
