### PR TITLE
tidy up datepicker module

### DIFF
--- a/components/datepicker/datepicker-popup.component.ts
+++ b/components/datepicker/datepicker-popup.component.ts
@@ -8,7 +8,7 @@ import { KeyAttribute } from '../common';
 import { positionService } from '../position';
 import { ComponentsHelper } from '../utils/components-helper.service';
 
-class PopupOptions {
+export class PopupOptions {
   public placement:string;
   public animation:boolean;
   public isOpen:boolean;
@@ -36,7 +36,7 @@ const datePickerPopupConfig:KeyAttribute = {
         [ngStyle]="{top: top, left: left, display: display}"
         [ngClass]="classMap">
         <li>
-             <datepicker (cupdate)="onUpdate($event)" *ngIf="popupComp" [(ngModel)]="popupComp.cd.model" [show-weeks]="true"></datepicker>
+             <datepicker (selectionDone)="onUpdate($event)" *ngIf="popupComp" [(ngModel)]="popupComp.cd.model" [showWeeks]="true"></datepicker>
         </li>
         <li *ngIf="showButtonBar" style="padding:10px 9px 2px">
             <span class="btn-group pull-left">
@@ -48,7 +48,7 @@ const datePickerPopupConfig:KeyAttribute = {
     </ul>`,
   encapsulation: ViewEncapsulation.None
 })
-class PopupContainerComponent {
+export class PopupContainerComponent {
   public popupComp:DatePickerPopupDirective;
 
   private classMap:any;

--- a/components/datepicker/datepicker.module.ts
+++ b/components/datepicker/datepicker.module.ts
@@ -2,21 +2,21 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { DatePickerInnerComponent } from './datepicker-inner.component';
-// import {DatePickerPopup} from './datepicker-popup';
-import { DatePickerPopupDirective } from './datepicker-popup.component';
+import { ComponentsHelper } from '../utils/components-helper.service';
+
 import { DatePickerComponent } from './datepicker.component';
+import { DatePickerInnerComponent } from './datepicker-inner.component';
+import { DatePickerPopupDirective, PopupContainerComponent } from './datepicker-popup.component';
 import { DayPickerComponent } from './daypicker.component';
 import { MonthPickerComponent } from './monthpicker.component';
 import { YearPickerComponent } from './yearpicker.component';
-import { ComponentsHelper } from '../utils/components-helper.service';
 
 @NgModule({
   imports: [CommonModule, FormsModule],
   declarations: [DatePickerComponent, DatePickerInnerComponent, DatePickerPopupDirective, DayPickerComponent,
-                 MonthPickerComponent, YearPickerComponent],
-  exports: [DatePickerComponent, DatePickerInnerComponent, DatePickerPopupDirective, DayPickerComponent, FormsModule,
-            MonthPickerComponent, YearPickerComponent],
+                 MonthPickerComponent, PopupContainerComponent, YearPickerComponent],
+  exports: [DatePickerComponent, DatePickerPopupDirective, DayPickerComponent, FormsModule, MonthPickerComponent,
+            YearPickerComponent],
   providers: [ComponentsHelper]
 })
 export class DatepickerModule {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "reflect-metadata": "0.1.8",
     "require-dir": "0.3.0",
     "rxjs": "5.0.0-beta.11",
-    "systemjs-builder": "0.15.30",
+    "systemjs-builder": "0.15.31",
     "tslint-config-valorsoft": "1.1.1",
     "typedoc": "0.4.5",
     "typescript": "1.8.10",


### PR DESCRIPTION
try to fix some weird code which was explored in https://github.com/valor-software/ng2-bootstrap/issues/929

The `PopupContainerComponent` is not declared inside the `DatapickerModule`.
The related template contains `show-weeks` and `cupdate` which are not part of the `DatePickerComponent`. I thing it should `showWeeks` and `selectionDone`.

Hide `DatePickerInnerComponent` and `PopupContainerComponent` by removing them from `exports` because this are internal components!?
