### PR TITLE
Exclude all node_modules contents on lint

### DIFF
--- a/gulp-tasks/lint.js
+++ b/gulp-tasks/lint.js
@@ -4,6 +4,7 @@ const gulp = require('gulp');
 const tslint = require('gulp-tslint');
 const gitignore = require('gitignore-to-glob')();
 
+gitignore.push('!node_modules/**/*');
 gitignore.push('**/*.ts');
 
 gulp.task('tslint', () =>


### PR DESCRIPTION
Tried to build everything on windows again, and it works nicely. Thanks for the effort on this :+1: 

One small thing: need to manually exclude all node_module contents in the lint task, otherwise it will try to lint all the installed modules. Experienced this on windows, on linux everything was fine.
