### PR TITLE
fix(datepicker): Fix Angular 2.0.0 error thrown from template when property starts with 'on'

### DIFF
--- a/components/datepicker/datepicker-inner.component.ts
+++ b/components/datepicker/datepicker-inner.component.ts
@@ -60,7 +60,7 @@ export class DatePickerInnerComponent implements OnInit, OnChanges {
   @Input() public formatDayHeader:string;
   @Input() public formatDayTitle:string;
   @Input() public formatMonthTitle:string;
-  @Input() public onlyCurrentMonth:boolean;
+  @Input() public currentMonthOnly:boolean;
   @Input() public shortcutPropagation:boolean;
   @Input() public customClass:Array<{date:Date, mode:string, clazz:string}>;
   // todo: change type during implementation
@@ -110,9 +110,9 @@ export class DatePickerInnerComponent implements OnInit, OnChanges {
     this.showWeeks = (this.showWeeks === undefined
       ? SHOW_WEEKS
       : this.showWeeks);
-    this.onlyCurrentMonth = (this.onlyCurrentMonth === undefined
+    this.currentMonthOnly = (this.currentMonthOnly === undefined
       ? ONLY_CURRENT_MONTH
-      : this.onlyCurrentMonth);
+      : this.currentMonthOnly);
     this.startingDay = this.startingDay || STARTING_DAY;
     this.yearRange = this.yearRange || YEAR_RANGE;
     this.shortcutPropagation = this.shortcutPropagation || SHORTCUT_PROPAGATION;

--- a/components/datepicker/datepicker.component.ts
+++ b/components/datepicker/datepicker.component.ts
@@ -24,7 +24,7 @@ import { ControlValueAccessor, NgModel } from '@angular/forms';
                       [yearRange]="yearRange"
                       [customClass]="customClass"
                       [dateDisabled]="dateDisabled"
-                      [onlyCurrentMonth]="onlyCurrentMonth"
+                      [currentMonthOnly]="currentMonthOnly"
                       [shortcutPropagation]="shortcutPropagation"
                       (selectionDone)="onSelectionDone($event)">
       <daypicker tabindex="0"></daypicker>
@@ -51,7 +51,7 @@ export class DatePickerComponent implements ControlValueAccessor {
   @Input() public formatMonthTitle:string;
   @Input() public startingDay:number;
   @Input() public yearRange:number;
-  @Input() public onlyCurrentMonth:boolean;
+  @Input() public currentMonthOnly:boolean;
   @Input() public shortcutPropagation:boolean;
   @Input() public customClass:Array<{date:Date, mode:string, clazz:string}>;
 // todo: change type during implementation

--- a/components/datepicker/daypicker.component.ts
+++ b/components/datepicker/daypicker.component.ts
@@ -13,7 +13,7 @@ const TEMPLATE_OPTIONS:any = {
         <td *ngIf="datePicker.showWeeks" class="text-xs-center h6"><em>{{ weekNumbers[index] }}</em></td>
         <td *ngFor="let dtz of rowz" class="text-xs-center" role="gridcell" [id]="dtz.uid">
           <button type="button" style="min-width:100%;" class="btn btn-sm {{dtz.customClass}}"
-                  *ngIf="!(datePicker.onlyCurrentMonth && dtz.secondary)"
+                  *ngIf="!(datePicker.currentMonthOnly && dtz.secondary)"
                   [ngClass]="{'btn-secondary': !dtz.selected && !datePicker.isActive(dtz), 'btn-info': dtz.selected, disabled: dtz.disabled}"
                   [disabled]="dtz.disabled"
                   (click)="datePicker.select(dtz.date)" tabindex="-1">
@@ -32,7 +32,7 @@ const TEMPLATE_OPTIONS:any = {
         <td *ngIf="datePicker.showWeeks" class="text-center h6"><em>{{ weekNumbers[index] }}</em></td>
         <td *ngFor="let dtz of rowz" class="text-center" role="gridcell" [id]="dtz.uid">
           <button type="button" style="min-width:100%;" class="btn btn-default btn-sm {{dtz.customClass}}"
-                  *ngIf="!(datePicker.onlyCurrentMonth && dtz.secondary)"
+                  *ngIf="!(datePicker.currentMonthOnly && dtz.secondary)"
                   [ngClass]="{'btn-info': dtz.selected, active: datePicker.isActive(dtz), disabled: dtz.disabled}"
                   [disabled]="dtz.disabled"
                   (click)="datePicker.select(dtz.date)" tabindex="-1">
@@ -84,7 +84,7 @@ const CURRENT_THEME_TEMPLATE:any = TEMPLATE_OPTIONS[Ng2BootstrapConfig.theme || 
   </thead>
   <tbody>
     <template ngFor [ngForOf]="rows" let-rowz="$implicit" let-index="index">
-      <tr *ngIf="!(datePicker.onlyCurrentMonth && rowz[0].secondary && rowz[6].secondary)">
+      <tr *ngIf="!(datePicker.currentMonthOnly && rowz[0].secondary && rowz[6].secondary)">
         ${CURRENT_THEME_TEMPLATE.WEEK_ROW}
       </tr>
     </template>

--- a/components/datepicker/readme.md
+++ b/components/datepicker/readme.md
@@ -33,7 +33,7 @@ import { DatepickerModule } from 'ng2-bootstrap/components/datepicker';
   - `formatMonthTitle` (`?string='yyyy'`) - format of title when selecting month
   - `yearRange` (`?number=20`) - number of years displayed in year selection
   - `shortcutPropagation` (`?boolean=false`) - if `true` shortcut`s event propagation will be disabled
-  - `onlyCurrentMonth` (`?boolean=false`) - if `true` only dates from the currently displayed month will be shown
+  - `currentMonthOnly` (`?boolean=false`) - if `true` only dates from the currently displayed month will be shown
 
 <!--
 ### Date picker popup properties


### PR DESCRIPTION
Closes #1000
Relates to https://github.com/angular/angular/issues/11756

This unfortunately is a breaking change due a change to the public API
