### PR TITLE
fix(datepicker): changing model value changes the view correctly

### DIFF
--- a/components/datepicker/datepicker.component.ts
+++ b/components/datepicker/datepicker.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, Output, Self } from '@angular/core';
+import { Component, EventEmitter, Input, Output, Self, ViewChild } from '@angular/core';
+import { DatePickerInnerComponent } from './datepicker-inner.component';
 import { ControlValueAccessor, NgModel } from '@angular/forms';
 
 /* tslint:disable:component-selector-name component-selector-type */
@@ -66,6 +67,8 @@ export class DatePickerComponent implements ControlValueAccessor {
   private _now:Date = new Date();
   private _activeDate:Date;
 
+  @ViewChild(DatePickerInnerComponent) private datePicker: DatePickerInnerComponent;
+
   @Input()
   public get activeDate():Date {
     return this._activeDate || this._now;
@@ -82,7 +85,6 @@ export class DatePickerComponent implements ControlValueAccessor {
   }
 
   public onUpdate(event:any):void {
-    this.writeValue(event);
     this.cd.viewToModelUpdate(event);
   }
 
@@ -92,19 +94,12 @@ export class DatePickerComponent implements ControlValueAccessor {
 
   // todo: support null value
   public writeValue(value:any):void {
-    // todo: fix something sends here new date all the time
-    // if (value) {
-    //  if (typeof value !== 'Date') {
-    //    value = new Date(value);
-    //  }
-    //
-    //  this.activeDate = value;
-    // }
-    if (value === this._activeDate) {
+    if (this.datePicker.compare(value, this._activeDate) === 0) {
       return;
     }
     if (value && value instanceof Date) {
       this.activeDate = value;
+      this.datePicker.select(value);
       return;
     }
 


### PR DESCRIPTION
Resolves #858 
The problem was when the change happened from the model, the view wasn't updated properly - the change wasn't propagated to the inner component and all the attributes of date object like `selected` and `current` were not updated. 
