### PR TITLE
Fixed #1051. Hide modal dialog before destroying component

### DIFF
--- a/components/modal/modal.component.ts
+++ b/components/modal/modal.component.ts
@@ -95,6 +95,7 @@ export class ModalDirective implements AfterViewInit, OnDestroy {
   }
 
   public ngOnDestroy(): any {
+    this.hide();
     this.config = void 0;
     // this._element             = null
     // this._dialog              = null


### PR DESCRIPTION
Before destroying the modal component hide() method will restore initial state of the page.
