### PR TITLE
fix(typeahead): Fix crash with `contenteditable` inputs

### DIFF
--- a/components/typeahead/typeahead.directive.ts
+++ b/components/typeahead/typeahead.directive.ts
@@ -92,7 +92,10 @@ export class TypeaheadDirective implements OnInit {
       }
     }
 
-    if (e.target.value.trim().length >= this.typeaheadMinLength) {
+    // For `<input>`s, use the `value` property. For others that don't have a
+    // `value` (such as `<span contenteditable="true">`, use `innerText`.
+    const value = e.target.value !== undefined ? e.target.value : e.target.innerText;
+    if (value.trim().length >= this.typeaheadMinLength) {
       this.typeaheadLoading.emit(true);
       this.keyUpEventEmitter.emit(e.target.value);
     } else {


### PR DESCRIPTION
Currently the Typeahead module works well with `<input>`s, but throws an error for HTML5 [`contenteditable` inputs](http://www.w3schools.com/tags/att_global_contenteditable.asp).

This patch fixes this by using the `innerText` property (the one used for contenteditable inputs) when `value` is not available.
