### PR TITLE
Adding support for wallaby.js

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -24,6 +24,7 @@ tsconfig.json
 tsconfig.publish.json
 tslint.json
 typedoc.js
+wallaby.js
 
 # demo build
 doc

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "tslint-config-valorsoft": "1.1.1",
     "typedoc": "0.4.5",
     "typescript": "2.0.3",
+    "wallaby-webpack": "0.0.24",
     "zone.js": "0.6.23"
   }
 }

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const wallabyWebpack = require('wallaby-webpack');
+const webpackPostprocessor = wallabyWebpack({
+  entryPatterns: [
+    'spec-bundle.js',
+    'components/**/*spec.js'
+  ],
+
+  module: {
+    loaders: [
+      {test: /\.css$/, loader: 'raw-loader'},
+      {test: /\.html$/, loader: 'raw-loader'}
+    ]
+  }
+});
+
+module.exports = function conifg() {
+  return {
+    files: [
+      {pattern: 'spec-bundle.js', load: false},
+      {pattern: 'components/**/*.ts', load: false},
+      {pattern: 'components/**/*.css', load: false},
+      {pattern: 'components/**/*.html', load: false},
+      '!components/**/*.spec.ts'
+    ],
+
+    tests: [
+      {pattern: 'components/**/*.spec.ts', load: false}
+    ],
+
+    testFramework: 'jasmine',
+
+    env: {
+      runner: require('phantomjs-prebuilt').path,  // eslint-disable-line
+      params: {runner: '--web-security=false'}
+    },
+
+    postprocessor: webpackPostprocessor,
+
+    setup: () => window.__moduleBundler.loadTests()  // eslint-disable-line
+  };
+};


### PR DESCRIPTION
Great continuous test runner. 
Will drop this here in case other people use it.

We only need two small changes:
- add wallaby webpack module
- wallaby config file

This will allow wallaby to work in any of the supported editors.
(Only tested in vs code though, can do additional testing if required)
