### PR TITLE
feat(typeahead): add grouping of typeahead matches

### DIFF
--- a/components/typeahead/readme.md
+++ b/components/typeahead/readme.md
@@ -21,6 +21,7 @@ export class TypeaheadDirective implements OnInit {
   @Input() public typeaheadWaitMs:number;
   @Input() public typeaheadOptionsLimit:number;
   @Input() public typeaheadOptionField:string;
+  @Input() public typeaheadGroupField:string;
   @Input() public typeaheadAsync:boolean = null;
   @Input() public typeaheadLatinize:boolean = true;
   @Input() public typeaheadSingleWords:boolean = true;
@@ -46,7 +47,8 @@ export class TypeaheadDirective implements OnInit {
   - `typeaheadMinLength` (`?number=1`) - minimal no of characters that needs to be entered before typeahead kicks-in. When set to 0, typeahead shows on focus with full list of options (limited as normal by typeaheadOptionsLimit)
   - `typeaheadWaitMs` (`?number=0`) - minimal wait time after last character typed before typeahead kicks-in
   - `typeaheadOptionsLimit` (`?number=20`) - maximum length of options items list
-  - `typeaheadOptionField` (`?string`) - name of field in array of states that contain options as objects, we use array item as option in case of this field is missing. Supports nested properties and methods
+  - `typeaheadOptionField` (`?string`) - when options source is an array of objects, the name of field that contains the options value, we use array item as option in case of this field is missing. Supports nested properties and methods.
+  - `typeaheadGroupField` (`?string`) - when options source is an array of objects, the name of field that contains the group value, matches are grouped by this field when set.
   - `typeaheadAsync` (`?boolean`) - should be used only in case of `typeahead` attribute is array. If `true` - loading of options will be async, otherwise - sync. `true` make sense if options array is large.
   - `typeaheadLatinize` (`?boolean=true`) - match latin symbols. If `true` the word `súper` would match `super` and vice versa.
   - `typeaheadSingleWords` (`?boolean=true`) - break words with spaces. If `true` the text `"exact phrase" here match` would match with `match exact phrase here` but not with `phrase here exact match` (kind of "google style").

--- a/components/typeahead/typeahead-container.component.spec.ts
+++ b/components/typeahead/typeahead-container.component.spec.ts
@@ -75,20 +75,134 @@ describe('Component: TypeaheadContainer', () => {
       matches = asNativeElements(fixture.debugElement.queryAll(By.css('.dropdown-menu li')));
     });
 
-    it('should render 2 matches', () => {
-      expect(matches.length).toBe(2);
+    describe('rendering', () => {
+      it('should render 2 matches', () => {
+        expect(matches.length).toBe(2);
+      });
+
+      it('should highlight query for match', () => {
+        expect(matches[1].children[0].innerHTML).toBe('<strong>fo</strong>od');
+      });
+
+      it('should set the \"active\" class on the first match', () => {
+        expect(matches[0].classList.contains('active')).toBeTruthy();
+      });
+
+      it('should not set the \"active\" class on other matches', () => {
+        expect(matches[1].classList.contains('active')).toBeFalsy();
+      });
     });
 
-    it('should highlight query for match', () => {
-      expect(matches[1].children[0].innerHTML).toBe('<strong>fo</strong>od');
+    describe('nextActiveMatch', () => {
+      it('should select the next match', () => {
+        component.nextActiveMatch();
+
+        expect(component.isActive(component.matches[1])).toBeTruthy();
+      });
+
+      it('should select the first match again, when triggered twice', () => {
+        component.nextActiveMatch();
+        component.nextActiveMatch();
+
+        expect(component.isActive(component.matches[0])).toBeTruthy();
+      });
     });
 
-    it('should set the \"active\" class on the first match', () => {
-      expect(matches[0].classList.contains('active')).toBeTruthy();
+    describe('prevActiveMatch', () => {
+      it('should select the previous (last) match', () => {
+        component.prevActiveMatch();
+
+        expect(component.isActive(component.matches[1])).toBeTruthy();
+      });
+
+      it('should select the first match again, when triggered twice', () => {
+        component.prevActiveMatch();
+        component.prevActiveMatch();
+
+        expect(component.isActive(component.matches[0])).toBeTruthy();
+      });
+    });
+  });
+
+  describe('grouped matches', () => {
+    let itemMatches:HTMLLIElement[];
+    let headerMatch:HTMLLIElement;
+
+    beforeEach(() => {
+      component.query = 'a';
+      component.matches = [
+        new TypeaheadMatch('fruits', 'fruits', true),
+        new TypeaheadMatch({id: 0, name: 'banana', category: 'fruits'}, 'banana'),
+        new TypeaheadMatch({id: 0, name: 'apple', category: 'fruits'}, 'apple')
+      ];
+
+      fixture.detectChanges();
+      headerMatch = fixture.debugElement.query(By.css('.dropdown-header')).nativeElement;
+      itemMatches = asNativeElements(fixture.debugElement.queryAll(By.css('.dropdown-menu li:not(.dropdown-header)')));
     });
 
-    it('should not set the \"active\" class on other matches', () => {
-      expect(matches[1].classList.contains('active')).toBeFalsy();
+    describe('rendering', () => {
+      it('should render 2 item matches', () => {
+        expect(itemMatches.length).toBe(2);
+      });
+
+      it('should highlight query for item match', () => {
+        expect(itemMatches[1].children[0].innerHTML).toBe('<strong>a</strong>pple');
+      });
+
+      it('should set the \"active\" class on the first item match', () => {
+        expect(itemMatches[0].classList.contains('active')).toBeTruthy();
+      });
+
+      it('should not set the \"active\" class on the header match', () => {
+        expect(headerMatch.classList.contains('active')).toBeFalsy();
+      });
+
+      it('should render 1 header match', () => {
+        expect(headerMatch.innerHTML).toBe('fruits');
+      });
+    });
+
+    describe('nextActiveMatch', () => {
+      it('should select the next item match', () => {
+        component.nextActiveMatch();
+
+        expect(component.isActive(component.matches[2])).toBeTruthy();
+      });
+
+      it('should skip the header match, when triggered twice', () => {
+        component.nextActiveMatch();
+        component.nextActiveMatch();
+
+        expect(component.isActive(component.matches[0])).toBeFalsy();
+      });
+    });
+
+    describe('prevActiveMatch', () => {
+      it('should skip the header match', () => {
+        component.prevActiveMatch();
+
+        expect(component.isActive(component.matches[0])).toBeFalsy();
+      });
+
+      it('should select the first match again, when triggered twice', () => {
+        component.prevActiveMatch();
+        component.prevActiveMatch();
+
+        expect(component.isActive(component.matches[1])).toBeTruthy();
+      });
+    });
+  });
+
+  describe('isFocused', () => {
+    it('should not be focus after init', () => {
+      expect(component.isFocused).toBeFalsy();
+    });
+
+    it('should not be focused on focusLost()', () => {
+      component.focusLost();
+
+      expect(component.isFocused).toBeFalsy();
     });
   });
 

--- a/components/typeahead/typeahead-container.component.spec.ts
+++ b/components/typeahead/typeahead-container.component.spec.ts
@@ -1,0 +1,91 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TypeaheadContainerComponent } from './typeahead-container.component';
+import { TypeaheadOptions } from './typeahead-options.class';
+import { asNativeElements } from '@angular/core';
+
+describe('Component: TypeaheadContainer', () => {
+  let fixture:ComponentFixture<TypeaheadContainerComponent>;
+  let component:TypeaheadContainerComponent;
+
+  beforeEach(() => {
+    fixture = TestBed.configureTestingModule({
+      declarations: [TypeaheadContainerComponent],
+      providers: [{
+        provide: TypeaheadOptions,
+        useValue: new TypeaheadOptions({animation: false, placement: 'bottom-left', typeaheadRef: undefined})
+      }]
+    }).createComponent(TypeaheadContainerComponent);
+
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be defined', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have an \"element\" property', () => {
+    expect(component.element).toBeTruthy();
+  });
+
+  it('should have an empty \"matches\" array', () => {
+    expect(component.matches.length).toBe(0);
+  });
+
+  describe('dropdown-menu', () => {
+    let dropDown:HTMLElement;
+
+    beforeEach(() => {
+      component.position(fixture.elementRef);
+      fixture.detectChanges();
+
+      dropDown = fixture.debugElement.query(By.css('.dropdown-menu')).nativeElement as HTMLElement;
+    });
+
+    it('should be rendered', () => {
+      expect(dropDown).toBeDefined();
+    });
+
+    it('should have display style set', () => {
+      expect(dropDown.style.display).toBe('block');
+    });
+
+    it('should have top style set', () => {
+      expect(dropDown.style.top).toBe('16px');
+    });
+
+    it('should have left style set', () => {
+      expect(dropDown.style.left).toBe('8px');
+    });
+  });
+
+  describe('matches', () => {
+    let matches:HTMLLIElement[];
+
+    beforeEach(() => {
+      component.query = 'fo';
+      component.matches = ['foo', 'food'];
+      fixture.detectChanges();
+
+      matches = asNativeElements(fixture.debugElement.queryAll(By.css('.dropdown-menu li')));
+    });
+
+    it('should render 2 matches', () => {
+      expect(matches.length).toBe(2);
+    });
+
+    it('should highlight query for match', () => {
+      expect(matches[1].children[0].innerHTML).toBe('<strong>fo</strong>od');
+    });
+
+    it('should set the \"active\" class on the first match', () => {
+      expect(matches[0].classList.contains('active')).toBeTruthy();
+    });
+
+    it('should not set the \"active\" class on other matches', () => {
+      expect(matches[1].classList.contains('active')).toBeFalsy();
+    });
+  });
+
+});

--- a/components/typeahead/typeahead-container.component.spec.ts
+++ b/components/typeahead/typeahead-container.component.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { asNativeElements } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { TypeaheadContainerComponent } from './typeahead-container.component';
 import { TypeaheadOptions } from './typeahead-options.class';
-import { asNativeElements } from '@angular/core';
+import { TypeaheadMatch } from './typeahead-match.class';
 
 describe('Component: TypeaheadContainer', () => {
   let fixture:ComponentFixture<TypeaheadContainerComponent>;
@@ -65,7 +66,10 @@ describe('Component: TypeaheadContainer', () => {
 
     beforeEach(() => {
       component.query = 'fo';
-      component.matches = ['foo', 'food'];
+      component.matches = [
+        new TypeaheadMatch({id: 0, name: 'foo'}, 'foo'),
+        new TypeaheadMatch({id: 1, name: 'food'}, 'food')
+      ];
       fixture.detectChanges();
 
       matches = asNativeElements(fixture.debugElement.queryAll(By.css('.dropdown-menu li')));

--- a/components/typeahead/typeahead-container.component.ts
+++ b/components/typeahead/typeahead-container.component.ts
@@ -142,7 +142,7 @@ export class TypeaheadContainerComponent {
     }
   }
 
-  protected selectActive(value:any):void {
+  protected selectActive(value:TypeaheadMatch):void {
     this.isFocused = true;
     this._active = value;
   }
@@ -181,11 +181,11 @@ export class TypeaheadContainerComponent {
     this.isFocused = false;
   }
 
-  public isActive(value:any):boolean {
+  public isActive(value:TypeaheadMatch):boolean {
     return this._active === value;
   }
 
-  private selectMatch(value:any, e:Event = void 0):boolean {
+  private selectMatch(value:TypeaheadMatch, e:Event = void 0):boolean {
     if (e) {
       e.stopPropagation();
       e.preventDefault();

--- a/components/typeahead/typeahead-match.class.ts
+++ b/components/typeahead/typeahead-match.class.ts
@@ -1,0 +1,14 @@
+
+export class TypeaheadMatch {
+
+  public constructor(readonly item:any, readonly value:string = item, private header:boolean = false) {
+  }
+
+  public isHeader():boolean {
+    return this.header;
+  }
+
+  public toString():string {
+    return this.value;
+  }
+}

--- a/components/typeahead/typeahead.directive.spec.ts
+++ b/components/typeahead/typeahead.directive.spec.ts
@@ -4,6 +4,7 @@ import { Component, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { TypeaheadDirective } from './typeahead.directive';
 import { Observable } from 'rxjs';
+import { TypeaheadMatch } from './typeahead-match.class';
 
 const template = `
   <input [(ngModel)]="selectedState" [typeahead]="states" (typeaheadOnSelect)="typeaheadOnSelect($event)">
@@ -100,7 +101,7 @@ describe('Directive: Typeahead', () => {
       fixture.detectChanges();
       tick(100);
 
-      expect(directive.matches).toEqual(['Alabama', 'Alaska']);
+      expect(directive.matches).toEqual([new TypeaheadMatch('Alabama'), new TypeaheadMatch('Alaska')]);
     }));
 
     it('should result in 0 matches, when input does not match', fakeAsync(() => {

--- a/components/typeahead/typeahead.directive.spec.ts
+++ b/components/typeahead/typeahead.directive.spec.ts
@@ -1,0 +1,139 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TypeaheadModule } from './typeahead.module';
+import { Component, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { TypeaheadDirective } from './typeahead.directive';
+import { Observable } from 'rxjs';
+
+const template = `
+  <input [(ngModel)]="selectedState" [typeahead]="states" (typeaheadOnSelect)="typeaheadOnSelect($event)">
+`;
+
+@Component({
+  template
+})
+class TestTypeaheadComponent {
+  public selectedState:string;
+  public states:string[] = ['Alabama', 'Alaska', 'Arizona', 'Arkansas',
+    'California', 'Colorado',
+    'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho',
+    'Illinois', 'Indiana', 'Iowa',
+    'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts',
+    'Michigan', 'Minnesota',
+    'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire',
+    'New Jersey', 'New Mexico',
+    'New York', 'North Dakota', 'North Carolina', 'Ohio', 'Oklahoma', 'Oregon',
+    'Pennsylvania', 'Rhode Island',
+    'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont',
+    'Virginia', 'Washington',
+    'West Virginia', 'Wisconsin', 'Wyoming'];
+}
+
+describe('Directive: Typeahead', () => {
+  let fixture:ComponentFixture<TestTypeaheadComponent>;
+  let component:TestTypeaheadComponent;
+  let directive:TypeaheadDirective;
+  let inputElement:HTMLInputElement;
+
+  beforeEach(() => {
+    fixture = TestBed.configureTestingModule({
+      declarations: [TestTypeaheadComponent],
+      imports: [TypeaheadModule]
+    }).createComponent(TestTypeaheadComponent);
+
+    fixture.detectChanges();
+
+    component = fixture.componentInstance;
+    inputElement = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+
+    // get the typeahead directive instance
+    let inputs = fixture.debugElement.queryAll(By.directive(TypeaheadDirective));
+    directive = inputs.map((de:DebugElement) => de.injector.get(TypeaheadDirective) as TypeaheadDirective)[0];
+  });
+
+  it('should be defined on the test component', () => {
+    expect(directive).not.toBeNull();
+  });
+
+  describe('ngOnInit', () => {
+
+    it('should set a default value for typeaheadOptionsLimit', () => {
+      expect(directive.typeaheadOptionsLimit).toBe(20);
+    });
+
+    it('should set a default value for typeaheadMinLength', () => {
+      expect(directive.typeaheadMinLength).toBe(1);
+    });
+
+    it('should set a default value for typeaheadWaitMs', () => {
+      expect(directive.typeaheadWaitMs).toBe(0);
+    });
+
+    it('should set a default value for typeaheadAsync', () => {
+      expect(directive.typeaheadAsync).toBeFalsy();
+    });
+
+    it('should typeaheadAsync to false, if typeahead is an observable', () => {
+      directive.typeahead = Observable.of(component.states);
+      directive.ngOnInit();
+
+      expect(directive.typeaheadAsync).toBeTruthy();
+    });
+
+    it('should not render the typeahead-container', () => {
+      let typeaheadContainer = fixture.debugElement.query(By.css('typeahead-container'));
+
+      expect(typeaheadContainer).toBeNull();
+    });
+
+    it('should not set the container reference', () => {
+      expect(directive.container).toBeFalsy();
+    });
+  });
+
+  describe('onChange', () => {
+
+    it('should result in 2 matches, when \"Ala\" is entered', fakeAsync(() => {
+      inputElement.value = 'Ala';
+      inputElement.dispatchEvent(new Event('keyup'));
+
+      fixture.detectChanges();
+      tick(100);
+
+      expect(directive.matches).toEqual(['Alabama', 'Alaska']);
+    }));
+
+    it('should result in 0 matches, when input does not match', fakeAsync(() => {
+      inputElement.value = 'foo';
+      inputElement.dispatchEvent(new Event('keyup'));
+
+      fixture.detectChanges();
+      tick(100);
+
+      expect(directive.matches).toEqual([]);
+    }));
+
+  });
+
+  describe('show', () => {
+    beforeEach(fakeAsync(() => {
+      inputElement.value = 'California';
+      inputElement.dispatchEvent(new Event('keyup'));
+
+      fixture.detectChanges();
+      tick(100);
+    }));
+
+    it('should render the typeahead-container child element', () => {
+      fixture.detectChanges();
+      let typeaheadContainer = fixture.debugElement.query(By.css('typeahead-container'));
+
+      expect(typeaheadContainer).not.toBeNull();
+    });
+
+    it('should set the container reference', () => {
+      expect(directive.container).toBeTruthy();
+    });
+  });
+
+});

--- a/components/typeahead/typeahead.directive.ts
+++ b/components/typeahead/typeahead.directive.ts
@@ -175,8 +175,8 @@ export class TypeaheadDirective implements OnInit {
     }
   }
 
-  public changeModel(value:any):void {
-    let valueStr:string = TypeaheadUtils.getValueFromObject(value, this.typeaheadOptionField);
+  public changeModel(match:TypeaheadMatch):void {
+    let valueStr:string = match.value;
     this.ngControl.viewToModelUpdate(valueStr);
     (this.ngControl.control as FormControl).setValue(valueStr);
     this.hide();

--- a/demo/components/typeahead/typeahead-demo.html
+++ b/demo/components/typeahead/typeahead-demo.html
@@ -53,5 +53,13 @@
            class="form-control">
   </form>
 
-
+  <!-- Grouped results -->
+  <h4>Grouped results</h4>
+  <pre class="card card-block card-header">Model: {{groupSelected | json}}</pre>
+  <input [(ngModel)]="groupSelected"
+         [typeahead]="statesComplex"
+         [typeaheadOptionField]="'name'"
+         [typeaheadGroupField]="'region'"
+         (typeaheadOnSelect)="typeaheadOnSelect($event)"
+         class="form-control">
 </div>

--- a/demo/components/typeahead/typeahead-demo.ts
+++ b/demo/components/typeahead/typeahead-demo.ts
@@ -19,6 +19,7 @@ export class TypeaheadDemoComponent {
   });
 
   public customSelected:string = '';
+  public groupSelected:string = '';
   public selected:string = '';
   public dataSource:Observable<any>;
   public asyncSelected:string = '';
@@ -38,31 +39,31 @@ export class TypeaheadDemoComponent {
     'Virginia', 'Washington',
     'West Virginia', 'Wisconsin', 'Wyoming'];
   public statesComplex:Array<any> = [
-    {id: 1, name: 'Alabama'}, {id: 2, name: 'Alaska'}, {id: 3, name: 'Arizona'},
-    {id: 4, name: 'Arkansas'}, {id: 5, name: 'California'},
-    {id: 6, name: 'Colorado'}, {id: 7, name: 'Connecticut'},
-    {id: 8, name: 'Delaware'}, {id: 9, name: 'Florida'},
-    {id: 10, name: 'Georgia'}, {id: 11, name: 'Hawaii'},
-    {id: 12, name: 'Idaho'}, {id: 13, name: 'Illinois'},
-    {id: 14, name: 'Indiana'}, {id: 15, name: 'Iowa'},
-    {id: 16, name: 'Kansas'}, {id: 17, name: 'Kentucky'},
-    {id: 18, name: 'Louisiana'}, {id: 19, name: 'Maine'},
-    {id: 21, name: 'Maryland'}, {id: 22, name: 'Massachusetts'},
-    {id: 23, name: 'Michigan'}, {id: 24, name: 'Minnesota'},
-    {id: 25, name: 'Mississippi'}, {id: 26, name: 'Missouri'},
-    {id: 27, name: 'Montana'}, {id: 28, name: 'Nebraska'},
-    {id: 29, name: 'Nevada'}, {id: 30, name: 'New Hampshire'},
-    {id: 31, name: 'New Jersey'}, {id: 32, name: 'New Mexico'},
-    {id: 33, name: 'New York'}, {id: 34, name: 'North Dakota'},
-    {id: 35, name: 'North Carolina'}, {id: 36, name: 'Ohio'},
-    {id: 37, name: 'Oklahoma'}, {id: 38, name: 'Oregon'},
-    {id: 39, name: 'Pennsylvania'}, {id: 40, name: 'Rhode Island'},
-    {id: 41, name: 'South Carolina'}, {id: 42, name: 'South Dakota'},
-    {id: 43, name: 'Tennessee'}, {id: 44, name: 'Texas'},
-    {id: 45, name: 'Utah'}, {id: 46, name: 'Vermont'},
-    {id: 47, name: 'Virginia'}, {id: 48, name: 'Washington'},
-    {id: 49, name: 'West Virginia'}, {id: 50, name: 'Wisconsin'},
-    {id: 51, name: 'Wyoming'}];
+    {id: 1, name: 'Alabama', region: 'South'}, {id: 2, name: 'Alaska', region: 'West'}, {id: 3, name: 'Arizona', region: 'West'},
+    {id: 4, name: 'Arkansas', region: 'South'}, {id: 5, name: 'California', region: 'West'},
+    {id: 6, name: 'Colorado', region: 'West'}, {id: 7, name: 'Connecticut', region: 'Northeast'},
+    {id: 8, name: 'Delaware', region: 'South'}, {id: 9, name: 'Florida', region: 'South'},
+    {id: 10, name: 'Georgia', region: 'South'}, {id: 11, name: 'Hawaii', region: 'West'},
+    {id: 12, name: 'Idaho', region: 'West'}, {id: 13, name: 'Illinois', region: 'Midwest'},
+    {id: 14, name: 'Indiana', region: 'Midwest'}, {id: 15, name: 'Iowa', region: 'Midwest'},
+    {id: 16, name: 'Kansas', region: 'Midwest'}, {id: 17, name: 'Kentucky', region: 'South'},
+    {id: 18, name: 'Louisiana', region: 'South'}, {id: 19, name: 'Maine', region: 'Northeast'},
+    {id: 21, name: 'Maryland', region: 'South'}, {id: 22, name: 'Massachusetts', region: 'Northeast'},
+    {id: 23, name: 'Michigan', region: 'Midwest'}, {id: 24, name: 'Minnesota', region: 'Midwest'},
+    {id: 25, name: 'Mississippi', region: 'South'}, {id: 26, name: 'Missouri', region: 'Midwest'},
+    {id: 27, name: 'Montana', region: 'West'}, {id: 28, name: 'Nebraska', region: 'Midwest'},
+    {id: 29, name: 'Nevada', region: 'West'}, {id: 30, name: 'New Hampshire', region: 'Northeast'},
+    {id: 31, name: 'New Jersey', region: 'Northeast'}, {id: 32, name: 'New Mexico', region: 'West'},
+    {id: 33, name: 'New York', region: 'Northeast'}, {id: 34, name: 'North Dakota', region: 'Midwest'},
+    {id: 35, name: 'North Carolina', region: 'South'}, {id: 36, name: 'Ohio', region: 'Midwest'},
+    {id: 37, name: 'Oklahoma', region: 'South'}, {id: 38, name: 'Oregon', region: 'West'},
+    {id: 39, name: 'Pennsylvania', region: 'Northeast'}, {id: 40, name: 'Rhode Island', region: 'Northeast'},
+    {id: 41, name: 'South Carolina', region: 'South'}, {id: 42, name: 'South Dakota', region: 'Midwest'},
+    {id: 43, name: 'Tennessee', region: 'South'}, {id: 44, name: 'Texas', region: 'South'},
+    {id: 45, name: 'Utah', region: 'West'}, {id: 46, name: 'Vermont', region: 'Northeast'},
+    {id: 47, name: 'Virginia', region: 'South'}, {id: 48, name: 'Washington', region: 'South'},
+    {id: 49, name: 'West Virginia', region: 'South'}, {id: 50, name: 'Wisconsin', region: 'Midwest'},
+    {id: 51, name: 'Wyoming', region: 'West'}];
 
   public constructor() {
     this.dataSource = Observable.create((observer:any) => {


### PR DESCRIPTION
This PR adds support for grouping of typeahead matches by a configurable property given in the `[typeahead]` dataset.
### Example

Given a dataset of states with an `region` property:

`
let states =  [{id: 1, name: 'Alabama', region: 'South'}, {id: 2, name: 'Alaska', region: 'West'}];
`

And a typeahead directive configured with the `[typeaheadGroupField]`:

`
  <input [(ngModel)]="groupSelected"
         [typeahead]="states"
         [typeaheadOptionField]="'name'"
         [typeaheadGroupField]="'region'">
`

Would display a result grouped by region.
### Changes
- Added `[typeaheadGroupField]` for configurable grouping of matches
- Introduced `TypeaheadMatch` model class for more convenient handling of matches.
- Extended template rendering for grouped matches.
- Added Demo with example of grouped matches.
- Added tests for `TypeaheadDirective` and `TypeaheadContainerComponent`.
