### PR TITLE
fix(Typeahead): Emit `TypeaheadMatch`, not `{item: TypeaheadMatch}`

### DIFF
--- a/components/typeahead/typeahead-container.component.ts
+++ b/components/typeahead/typeahead-container.component.ts
@@ -192,9 +192,7 @@ export class TypeaheadContainerComponent {
     }
     this.parent.changeModel(value);
     setTimeout(() =>
-      this.parent.typeaheadOnSelect.emit({
-        item: value
-      }), 0
+      this.parent.typeaheadOnSelect.emit(value), 0
     );
     return false;
   }


### PR DESCRIPTION
Previously `(typeaheadOnSelect)` emitted:

```
Object {item: any}
```

from v1.1.10 it emits:

```
Object {item: TypeaheadMatch {item: any, value: string, header: string}}
```

whereas the intended value is:

```
TypeaheadMatch {item: any, value: string, header: string}
```

This commit fixes that.

Closes: #1103
