### PR TITLE
Add instructions for ModalModule import

### DIFF
--- a/components/modal/readme.md
+++ b/components/modal/readme.md
@@ -5,6 +5,8 @@ import { ModalModule } from 'ng2-bootstrap/ng2-bootstrap';
 import { ModalModule } from 'ng2-bootstrap/components/modal';
 ```
 
+Add the ModalModule import to the imports array of the child module that uses the modal, not the AppModule.
+
 ### Annotations
 ```typescript
 @Directive({


### PR DESCRIPTION
Given issues #1027 and #1143, ModalModule import instructions should indicate where to import the module.

Duplicate of closed PR #1171.