### PR TITLE
replacing unsafe-eval

### DIFF
--- a/components/utils/utils.class.ts
+++ b/components/utils/utils.class.ts
@@ -2,7 +2,7 @@ import { window } from './facade/browser';
 
 export class Utils {
   public static reflow(element: any): void {
-    new Function('bs', 'return bs')(element.offsetHeight);
+    element.offsetHeight;
   }
 
 // source: https://github.com/jquery/jquery/blob/master/src/css/var/getStyles.js

--- a/components/utils/utils.class.ts
+++ b/components/utils/utils.class.ts
@@ -2,7 +2,7 @@ import { window } from './facade/browser';
 
 export class Utils {
   public static reflow(element: any): void {
-    element.offsetHeight;
+    ((bs) => bs)(element.offsetHeight);
   }
 
 // source: https://github.com/jquery/jquery/blob/master/src/css/var/getStyles.js

--- a/components/utils/utils.class.ts
+++ b/components/utils/utils.class.ts
@@ -2,7 +2,7 @@ import { window } from './facade/browser';
 
 export class Utils {
   public static reflow(element: any): void {
-    ((bs) => bs)(element.offsetHeight);
+    ((bs: any): void => bs)(element.offsetHeight);
   }
 
 // source: https://github.com/jquery/jquery/blob/master/src/css/var/getStyles.js


### PR DESCRIPTION
`new Function()` call is causing runtime error in CSP environment, and doesn't appear to be having any effect, so I've changed it
closes #1242