### PR TITLE
Make modal hack docs reflect implementation of hack in demo

### DIFF
--- a/demo/src/app/components/modal/docs/title.md
+++ b/demo/src/app/components/modal/docs/title.md
@@ -7,14 +7,14 @@ Base specifications: [bootstrap 3](http://getbootstrap.com/javascript/#modals) o
 
 ```typescript
 import { Component, ViewContainerRef } from '@angular/core';
+import { ComponentsHelper } from 'ng2-bootstrap/ng2-bootstrap';
 
 @Component({selector:'app-root'})
 class AppRoot {
-  protected viewContainerRef: ViewContainerRef;
 
-  public constructor(viewContainerRef:ViewContainerRef) {
+  public constructor(componentsHelper:ComponentsHelper, viewContainerRef:ViewContainerRef) {
     // You need this small hack in order to catch application root view container ref
-    this.viewContainerRef = viewContainerRef;
+    componentsHelper.setRootViewContainerRef(viewContainerRef);
   }
 }
 ```


### PR DESCRIPTION
The implementation of the hack for setting the ApplicationRef in the modal demo was different from the documentation of how this should be done. This commit fixes this issue and brings the documentation inline with the implementation of the hack.