### PR TITLE
fix(karma.conf): fix for incorrect definition of mime type of test.ts file

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,6 +43,9 @@ module.exports = function (config) {
         base: 'Chrome',
         flags: ['--no-sandbox']
       }
+    },
+    mime: {
+      'text/x-typescript': ['ts','tsx']
     }
   };
 


### PR DESCRIPTION
Chrome v.55 tried to run test.ts file as a video file. Setting *mime* option in karma.conf.js should fix it