### PR TITLE
ng2-bootstrap/ng2-bootstrap Deprecated

### DIFF
--- a/docs/getting-started/ng-cli.md
+++ b/docs/getting-started/ng-cli.md
@@ -24,7 +24,7 @@ ng serve
 - open `src/app/app.module.ts` and add
 
 ```typescript
-import { AlertModule } from 'ng2-bootstrap/ng2-bootstrap';
+import { AlertModule } from 'ng2-bootstrap';
 ...
 
 @NgModule({


### PR DESCRIPTION
New version of angular-cli displays deprecated warning:
ng2-bootstrap.js: 5 
DEPRECATED: please replace import of `ng2-bootstrap/ng2-bootstrap` with `ng2-bootstrap`