### PR TITLE
Changed reference to BrowserModule to CommonModule instead

### DIFF
--- a/src/sortable/sortable.module.ts
+++ b/src/sortable/sortable.module.ts
@@ -1,12 +1,12 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import {CommonModule} from "@angular/common";
 
 import { SortableComponent } from './sortable.component';
 import { DraggableItemService } from './draggable-item.service';
 
 @NgModule({
     declarations: [SortableComponent],
-    imports: [BrowserModule],
+    imports: [CommonModule],
     exports: [SortableComponent]
 })
 export class SortableModule {

--- a/src/sortable/sortable.module.ts
+++ b/src/sortable/sortable.module.ts
@@ -1,5 +1,5 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
-import {CommonModule} from "@angular/common";
+import { CommonModule } from '@angular/common';
 
 import { SortableComponent } from './sortable.component';
 import { DraggableItemService } from './draggable-item.service';


### PR DESCRIPTION
Importing `BrowserModule ` (into `SortableModule`) Caused error: 
`BrowserModule has already been loaded. If you need access to common directives such as NgIf and NgFor from a lazy loaded module, import CommonModule instead.`

After trying on lazy loaded app, that had `Ng2BootstrapModule.forRoot()` imported in root App Module.

ng2-bootstrap Library should not import BrowserModule anywhere.
See [NgModule Imports section of Angular Docs](https://angular.io/docs/ts/latest/guide/ngmodule.html#!#imports) for reference