### PR TITLE
Fix rollup error.

### DIFF
--- a/src/datepicker/date-formatter.ts
+++ b/src/datepicker/date-formatter.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 
 export class DateFormatter {
   public format(date:Date, format:string):string {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -13,6 +13,7 @@
     "declaration": true,
     "skipLibCheck": false,
     "stripInternal": true,
+    "allowSyntheticDefaultImports": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "lib": ["dom", "es6"],


### PR DESCRIPTION
I couldn't use ng2-bootstrap's datepicker as is with rollupjs because rollup cannot process `import * as moment from 'moment'`, instead `import moment from 'moment'` should work.
See https://github.com/rollup/rollup/issues/670