### PR TITLE
Update for typeahead.directive.ts

### DIFF
--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -136,7 +136,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
 
   @HostListener('focus')
   public onFocus(): void {
-    if (this.typeaheadMinLength === 0) {
+    if (this.typeaheadMinLength == 0) {
       this.typeaheadLoading.emit(true);
       this.keyUpEventEmitter.emit('');
     }


### PR DESCRIPTION
When set to typeaheadMinLength ===0(instead ==0), typeahead doesn't show on focus the full list of options