### PR TITLE
fix(styling-local): fix tooltip arrow styles

### DIFF
--- a/demo/src/app/components/+tooltip/demos/styling-local/styling-local.ts
+++ b/demo/src/app/components/+tooltip/demos/styling-local/styling-local.ts
@@ -10,7 +10,7 @@ import { Component } from '@angular/core';
   color: #fff;
 }
 :host >>> .tooltip .tooltip-arrow {
-  border-top-color: #009688;
+  border-bottom-color: #009688;
 }
   `]
 })


### PR DESCRIPTION
It has to be `border-bottom-color` to be able to change color of arrow.