### PR TITLE
FIX AOT & rollup compilation error

### DIFF
--- a/src/datepicker/date-formatter.ts
+++ b/src/datepicker/date-formatter.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 
 export class DateFormatter {
   public format(date:Date, format:string):string {


### PR DESCRIPTION
[FIX]: Cannot call a namespace ('moment')
node_modules/ng2-bootstrap/datepicker/date-formatter.js (6:15)