### PR TITLE
Include CDN instructions for Bootstrap 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ You will need bootstrap styles (Bootstrap 3)
 Or Bootstrap 4
 ```
 <!--- index.html -->
-<linkhref="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" rel="stylesheet">
 ```
+Hot to enable bootstrap 4 theme templates in ng2-bootstrap, please read
+[here](https://github.com/valor-software/ng2-bootstrap/blob/development/docs/getting-started/bootstrap4.md)
 
 ```
 <!-- index.html -->

--- a/README.md
+++ b/README.md
@@ -32,12 +32,24 @@ Install `ng2-bootstrap` from `npm`
 npm install ng2-bootstrap --save
 ```
 
-You will need bootstrap styles
+You will need bootstrap styles (Bootstrap 3)
 
 ```
 <!-- index.html -->
 <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
 ```
+
+Or Bootstrap 4
+```
+<!--- index.html -->
+<linkhref="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" rel="stylesheet">
+```
+
+```
+<!-- index.html -->
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
+```
+
 
 ## How to use it with:
  - `angular-cli` please refer to [getting-started-with-ng-cli](https://github.com/valor-software/ng2-bootstrap/tree/development/docs/getting-started/ng-cli.md)


### PR DESCRIPTION
Seems an easy way to get stuck for beginners, it's not clear that there's a version3, and version4 alternative