### PR TITLE
added support for angular v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
     "moment": "2.18.1"
   },
   "peerDependencies": {
-    "@angular/common": "^2.3.1",
-    "@angular/compiler": "^2.3.1",
-    "@angular/core": "^2.3.1",
-    "@angular/forms": "^2.3.1"
+    "@angular/common": "^2.3.1 || ^4.0.0",
+    "@angular/compiler": "^2.3.1 || ^4.0.0",
+    "@angular/core": "^2.3.1 || ^4.0.0",
+    "@angular/forms": "^2.3.1 || ^4.0.0"
   },
   "devDependencies": {
     "@angular/cli": "1.0.0",


### PR DESCRIPTION
Fixes #1807

^ This is a very small PR that contains peerDependencies adjustments needed to support Angular v4.x. This library 'll now supports both 4.x and 2.x.