### PR TITLE
Added minuteRoundBeforeStep option to timepicker

### DIFF
--- a/src/timepicker/timepicker.component.ts
+++ b/src/timepicker/timepicker.component.ts
@@ -18,8 +18,9 @@ function isDefined(value: any): boolean {
   return typeof value !== 'undefined';
 }
 
+
 function addMinutes(date: any, minutes: number, minuteRoundBeforeStep?:boolean): Date {
-  let dt = new Date(date.getTime() + (minuteRoundBeforeStep?(minutes - (date.getMinutes() % minutes ))):minutes) * 60000);
+  let dt = new Date(date.getTime() + (minuteRoundBeforeStep?(minutes - (date.getMinutes() % minutes )):minutes) * 60000);
   let newDate = new Date(date);
   newDate.setHours(dt.getHours(), dt.getMinutes());
   return newDate;
@@ -276,25 +277,25 @@ export class TimepickerComponent implements ControlValueAccessor, OnInit {
   }
 
   public noIncrementHours(): boolean {
-    let incrementedSelected = addMinutes(this.selected, this.hourStep * 60, minuteRoundBeforeStep);
+    let incrementedSelected = addMinutes(this.selected, this.hourStep * 60, this.minuteRoundBeforeStep);
     return incrementedSelected > this.max ||
       (incrementedSelected < this.selected && incrementedSelected < this.min);
   }
 
   public noDecrementHours(): boolean {
-    let decrementedSelected = addMinutes(this.selected, -this.hourStep * 60, minuteRoundBeforeStep);
+    let decrementedSelected = addMinutes(this.selected, -this.hourStep * 60, this.minuteRoundBeforeStep);
     return decrementedSelected < this.min ||
       (decrementedSelected > this.selected && decrementedSelected > this.max);
   }
 
   public noIncrementMinutes(): boolean {
-    let incrementedSelected = addMinutes(this.selected, this.minuteStep, minuteRoundBeforeStep);
+    let incrementedSelected = addMinutes(this.selected, this.minuteStep, this.minuteRoundBeforeStep);
     return incrementedSelected > this.max ||
       (incrementedSelected < this.selected && incrementedSelected < this.min);
   }
 
   public noDecrementMinutes(): boolean {
-    let decrementedSelected = addMinutes(this.selected, -this.minuteStep, minuteRoundBeforeStep);
+    let decrementedSelected = addMinutes(this.selected, -this.minuteStep, this.minuteRoundBeforeStep);
     return decrementedSelected < this.min ||
       (decrementedSelected > this.selected && decrementedSelected > this.max);
 
@@ -313,9 +314,9 @@ export class TimepickerComponent implements ControlValueAccessor, OnInit {
     }
 
     if (this.selected.getHours() < 13) {
-      return addMinutes(this.selected, 12 * 60, minuteRoundBeforeStep) > this.max;
+      return addMinutes(this.selected, 12 * 60, this.minuteRoundBeforeStep) > this.max;
     } else {
-      return addMinutes(this.selected, -12 * 60, minuteRoundBeforeStep) < this.min;
+      return addMinutes(this.selected, -12 * 60, this.minuteRoundBeforeStep) < this.min;
     }
   }
 
@@ -382,7 +383,7 @@ export class TimepickerComponent implements ControlValueAccessor, OnInit {
   }
 
   protected addMinutesToSelected(minutes: any): void {
-    this.selected = addMinutes(this.selected, minutes, minuteRoundBeforeStep);
+    this.selected = addMinutes(this.selected, minutes, this.minuteRoundBeforeStep);
     this.refresh();
   }
 }

--- a/src/timepicker/timepicker.component.ts
+++ b/src/timepicker/timepicker.component.ts
@@ -18,8 +18,8 @@ function isDefined(value: any): boolean {
   return typeof value !== 'undefined';
 }
 
-function addMinutes(date: any, minutes: number): Date {
-  let dt = new Date(date.getTime() + minutes * 60000);
+function addMinutes(date: any, minutes: number, minuteRoundBeforeStep?:boolean): Date {
+  let dt = new Date(date.getTime() + (minuteRoundBeforeStep?(minutes - (date.getMinutes() % minutes ))):minutes) * 60000);
   let newDate = new Date(date);
   newDate.setHours(dt.getHours(), dt.getMinutes());
   return newDate;
@@ -76,6 +76,8 @@ export class TimepickerComponent implements ControlValueAccessor, OnInit {
   @Input() public max: Date;
   /** meridian labels based on locale */
   @Input() public meridians: string[];
+  /** Round current time to nearest step before stepping */
+  @Input() public minuteRoundBeforeStep: boolean;
 
   /** if true works in 12H mode and displays AM/PM. If false works in 24H mode and hides AM/PM */
   @Input()
@@ -274,25 +276,25 @@ export class TimepickerComponent implements ControlValueAccessor, OnInit {
   }
 
   public noIncrementHours(): boolean {
-    let incrementedSelected = addMinutes(this.selected, this.hourStep * 60);
+    let incrementedSelected = addMinutes(this.selected, this.hourStep * 60, minuteRoundBeforeStep);
     return incrementedSelected > this.max ||
       (incrementedSelected < this.selected && incrementedSelected < this.min);
   }
 
   public noDecrementHours(): boolean {
-    let decrementedSelected = addMinutes(this.selected, -this.hourStep * 60);
+    let decrementedSelected = addMinutes(this.selected, -this.hourStep * 60, minuteRoundBeforeStep);
     return decrementedSelected < this.min ||
       (decrementedSelected > this.selected && decrementedSelected > this.max);
   }
 
   public noIncrementMinutes(): boolean {
-    let incrementedSelected = addMinutes(this.selected, this.minuteStep);
+    let incrementedSelected = addMinutes(this.selected, this.minuteStep, minuteRoundBeforeStep);
     return incrementedSelected > this.max ||
       (incrementedSelected < this.selected && incrementedSelected < this.min);
   }
 
   public noDecrementMinutes(): boolean {
-    let decrementedSelected = addMinutes(this.selected, -this.minuteStep);
+    let decrementedSelected = addMinutes(this.selected, -this.minuteStep, minuteRoundBeforeStep);
     return decrementedSelected < this.min ||
       (decrementedSelected > this.selected && decrementedSelected > this.max);
 
@@ -311,9 +313,9 @@ export class TimepickerComponent implements ControlValueAccessor, OnInit {
     }
 
     if (this.selected.getHours() < 13) {
-      return addMinutes(this.selected, 12 * 60) > this.max;
+      return addMinutes(this.selected, 12 * 60, minuteRoundBeforeStep) > this.max;
     } else {
-      return addMinutes(this.selected, -12 * 60) < this.min;
+      return addMinutes(this.selected, -12 * 60, minuteRoundBeforeStep) < this.min;
     }
   }
 
@@ -380,7 +382,7 @@ export class TimepickerComponent implements ControlValueAccessor, OnInit {
   }
 
   protected addMinutesToSelected(minutes: any): void {
-    this.selected = addMinutes(this.selected, minutes);
+    this.selected = addMinutes(this.selected, minutes, minuteRoundBeforeStep);
     this.refresh();
   }
 }

--- a/src/timepicker/timepicker.config.ts
+++ b/src/timepicker/timepicker.config.ts
@@ -23,4 +23,6 @@ export class TimepickerConfig {
   public min: number = void 0;
   /** maximum time user can select */
   public max: number = void 0;
+  /** Round current time to nearest step before stepping */
+  public minuteRoundBeforeStep: boolean = true;
 }


### PR DESCRIPTION
if `minuteRoundBeforeStep` is `true` (default `true`), On first step, round current time to nearest minuteStep. 

**Example**: if current time is `05:23` and minuteStep is `5` increment will be in this order `05:25, 05:30, 05:35`
