### PR TITLE
'template'=>'ng-template'

### DIFF
--- a/demo/src/app/api-docs/api-doc-class/api-doc-class.component.html
+++ b/demo/src/app/api-docs/api-doc-class/api-doc-class.component.html
@@ -6,7 +6,7 @@
   </h3>
   <p [innerHtml]="apiDocs.description"></p>
 
-  <template [ngIf]="apiDocs.properties && apiDocs.properties.length">
+  <ng-template [ngIf]="apiDocs.properties && apiDocs.properties.length">
     <section>
       <h3 id="inputs">Properties</h3>
       <table class="table table-sm table-hover">
@@ -15,18 +15,18 @@
           <td class="col-xs-3"><code>{{prop.name}}</code></td>
           <td class="col-xs-9">
             <div><i>Type: </i><code>{{ prop.type }}</code></div>
-            <template [ngIf]="prop.defaultValue">
+            <ng-template [ngIf]="prop.defaultValue">
               <div><i>Default value: </i><code>{{prop.defaultValue || '-'}}</code></div>
-            </template>
+            </ng-template>
             <div><span [innerHtml]="prop.description"></span></div>
           </td>
         </tr>
         </tbody>
       </table>
     </section>
-  </template>
+  </ng-template>
 
-  <template [ngIf]="apiDocs.methods && apiDocs.methods.length">
+  <ng-template [ngIf]="apiDocs.methods && apiDocs.methods.length">
     <section>
       <h3 id="methods">Methods</h3>
       <table class="table table-sm table-hover">
@@ -43,6 +43,6 @@
         </tbody>
       </table>
     </section>
-  </template>
+  </ng-template>
 </div>
 <hr/>

--- a/demo/src/app/api-docs/api-doc-config/api-doc-config.component.html
+++ b/demo/src/app/api-docs/api-doc-config/api-doc-config.component.html
@@ -4,7 +4,7 @@
   </h3>
   <p [innerHtml]="apiDocs.description"></p>
 
-  <template [ngIf]="apiDocs.properties && apiDocs.properties.length">
+  <ng-template [ngIf]="apiDocs.properties && apiDocs.properties.length">
     <section>
       <h3 id="inputs">Properties</h3>
       <table class="table table-sm table-hover">
@@ -13,26 +13,26 @@
           <td class="col-xs-3"><code>{{prop.name}}</code></td>
           <td class="col-xs-9">
             <div><i>Type: </i><code>{{ prop.type }}</code></div>
-            <template [ngIf]="prop.defaultValue">
+            <ng-template [ngIf]="prop.defaultValue">
               <div><i>Default value: </i><code>{{prop.defaultValue || '-'}}</code></div>
-            </template>
+            </ng-template>
             <div [innerHtml]="prop.description"></div>
           </td>
         </tr>
         </tbody>
       </table>
     </section>
-  </template>
-  <!--<template [ngIf]="apiDocs.properties && apiDocs.properties.length">
+  </ng-template>
+  <!--<ng-template [ngIf]="apiDocs.properties && apiDocs.properties.length">
     <section>
       <h3 id="inputs">Properties</h3>
       <p>
-        <template ngFor let-property [ngForOf]="apiDocs.properties">
+        <ng-template ngFor let-property [ngForOf]="apiDocs.properties">
           <code>{{ property.name }}</code>
-        </template>
+        </ng-template>
         <i>&mdash; Documentation available in {{ directiveName }}</i>
       </p>
     </section>
-  </template>-->
+  </ng-template>-->
 </div>
 <hr/>

--- a/demo/src/app/api-docs/api-doc/api-doc.component.html
+++ b/demo/src/app/api-docs/api-doc/api-doc.component.html
@@ -16,7 +16,7 @@
       </tbody>
     </table>
 
-  <template [ngIf]="apiDocs.inputs.length">
+  <ng-template [ngIf]="apiDocs.inputs.length">
     <section>
       <h3 id="inputs">Inputs</h3>
       <table class="table table-sm table-hover">
@@ -25,21 +25,21 @@
           <td class="col-xs-3"><code>{{input.name}}</code></td>
           <td class="col-xs-9">
             <div><i>Type: </i><code>{{ input.type }}</code></div>
-            <template [ngIf]="defaultInputValue(input) || hasConfigProperty(input)">
+            <ng-template [ngIf]="defaultInputValue(input) || hasConfigProperty(input)">
               <div>
                 <span><i>Default value: </i><code>{{ defaultInputValue(input) || '-' }}</code></span>
                 <span *ngIf="hasConfigProperty(input)">&mdash; initialized from {{ configServiceName }} service</span>
               </div>
-            </template>
+            </ng-template>
             <div [innerHtml]="input.description"></div>
           </td>
         </tr>
         </tbody>
       </table>
     </section>
-  </template>
+  </ng-template>
 
-  <template [ngIf]="apiDocs.outputs.length">
+  <ng-template [ngIf]="apiDocs.outputs.length">
     <section>
       <h3 id="outputs">Outputs</h3>
       <table class="table table-sm table-hover">
@@ -51,9 +51,9 @@
         </tbody>
       </table>
     </section>
-  </template>
+  </ng-template>
 
-  <template [ngIf]="apiDocs.methods.length && apiDocs.exportAs">
+  <ng-template [ngIf]="apiDocs.methods.length && apiDocs.exportAs">
     <section>
       <h3 id="methods">Methods</h3>
       <table class="table table-sm table-hover">
@@ -69,6 +69,6 @@
         </tbody>
       </table>
     </section>
-  </template>
+  </ng-template>
 </div>
 <hr/>

--- a/demo/src/app/components/+popover/demos/dynamic-html/dynamic-html.html
+++ b/demo/src/app/components/+popover/demos/dynamic-html/dynamic-html.html
@@ -1,4 +1,4 @@
-<template #popTemplate>Here we go: <div [innerHtml]="html"></div></template>
+<ng-template #popTemplate>Here we go: <div [innerHtml]="html"></div></ng-template>
 <button type="button" class="btn btn-success"
         [popover]="popTemplate" popoverTitle="Dynamic html inside">
   Show me popover with html

--- a/demo/src/app/components/+popover/demos/dynamic/dynamic.html
+++ b/demo/src/app/components/+popover/demos/dynamic/dynamic.html
@@ -3,7 +3,7 @@
   Simple binding
 </button>
 
-<template #popTemplate>Just another: {{content}}</template>
+<ng-template #popTemplate>Just another: {{content}}</ng-template>
 <button type="button" class="btn btn-warning"
         [popover]="popTemplate" popoverTitle="Template ref content inside">
   TemplateRef binding

--- a/demo/src/app/components/+sortable/demos/custom-item-template/custom-item-template.html
+++ b/demo/src/app/components/+sortable/demos/custom-item-template/custom-item-template.html
@@ -1,4 +1,4 @@
-<template #itemTemplate let-item="item" let-index="index"><span>{{index}}: {{item.value}}</span></template>
+<ng-template #itemTemplate let-item="item" let-index="index"><span>{{index}}: {{item.value}}</span></ng-template>
 
 <div class="col-xs-6 col-md-3">
   <bs-sortable

--- a/demo/src/app/components/+tabs/demos/basic/basic.html
+++ b/demo/src/app/components/+tabs/demos/basic/basic.html
@@ -16,9 +16,9 @@
     <tab heading="Static Title 2">Static content 2</tab>
     <tab heading="Static Title 3" removable="true">Static content 3</tab>
     <tab (select)="alertMe()">
-      <template tabHeading>
+      <ng-template tabHeading>
         <i class="glyphicon glyphicon-bell"></i> Alert!
-      </template>
+      </ng-template>
       I've got an HTML heading, and a select callback. Pretty cool!
     </tab>
   </tabset>

--- a/demo/src/app/components/+tabs/docs/title.md
+++ b/demo/src/app/components/+tabs/docs/title.md
@@ -14,7 +14,7 @@ export class AppModule(){}
 <tabset>
   <tab heading='Tab 1'>Tab 1 content</tab>
   <tab>
-    <template tabHeading>Tab 2</template>
+    <ng-template tabHeading>Tab 2</ng-template>
     Tab 2 content
   </tab>
 </tabset>

--- a/demo/src/app/components/+tooltip/demos/dynamic-html/dynamic-html.html
+++ b/demo/src/app/components/+tooltip/demos/dynamic-html/dynamic-html.html
@@ -1,4 +1,4 @@
-<template #popTemplate>Here we go: <div [innerHtml]="html"></div></template>
+<ng-template #popTemplate>Here we go: <div [innerHtml]="html"></div></ng-template>
 <button type="button" class="btn btn-success"
         [tooltip]="popTemplate">
   Show me tooltip with html

--- a/demo/src/app/components/+tooltip/demos/dynamic/dynamic.html
+++ b/demo/src/app/components/+tooltip/demos/dynamic/dynamic.html
@@ -2,7 +2,7 @@
   Simple binding
 </button>
 
-<template #tolTemplate>Just another: {{content}}</template>
+<ng-template #tolTemplate>Just another: {{content}}</ng-template>
 <button type="button" class="btn btn-warning" [tooltip]="tolTemplate">
   TemplateRef binding
 </button>

--- a/demo/src/app/components/+typeahead/demos/item-template/item-template.html
+++ b/demo/src/app/components/+typeahead/demos/item-template/item-template.html
@@ -1,6 +1,6 @@
-<template #customItemTemplate let-model="item" let-index="index">
+<ng-template #customItemTemplate let-model="item" let-index="index">
   <h5>This is: {{model | json}} Index: {{ index }}</h5>
-</template>
+</ng-template>
 
 <pre class="card card-block card-header">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"

--- a/demo/src/ng-api-doc.ts
+++ b/demo/src/ng-api-doc.ts
@@ -1614,7 +1614,7 @@ export const ngdoc: any = {
   "TabHeadingDirective": {
     "fileName": "src/tabs/tab-heading.directive.ts",
     "className": "TabHeadingDirective",
-    "description": "<p>Should be used to mark <template> element as a template for tab heading </p>\n",
+    "description": "<p>Should be used to mark <ng-template> element as a template for tab heading </p>\n",
     "selector": "[tabHeading]",
     "inputs": [],
     "outputs": [],

--- a/src/alert/alert.component.ts
+++ b/src/alert/alert.component.ts
@@ -5,17 +5,17 @@ import { OnChange } from '../utils/decorators';
 @Component({
   selector: 'alert,ngx-alert',
   template: `
-<template [ngIf]="!isClosed">
+<ng-template [ngIf]="!isClosed">
   <div [class]="'alert alert-' + type" role="alert" [ngClass]="classes">
-    <template [ngIf]="dismissible">
+    <ng-template [ngIf]="dismissible">
       <button type="button" class="close" aria-label="Close" (click)="close()">
         <span aria-hidden="true">&times;</span>
         <span class="sr-only">Close</span>
       </button>
-    </template>
+    </ng-template>
     <ng-content></ng-content>
   </div>
-</template>
+</ng-template>
   `
 })
 export class AlertComponent implements OnInit {

--- a/src/datepicker/daypicker.component.ts
+++ b/src/datepicker/daypicker.component.ts
@@ -58,7 +58,7 @@ const TEMPLATE_OPTIONS: any = {
     </tr>
   </thead>
   <tbody>
-    <template ngFor [ngForOf]="rows" let-rowz="$implicit" let-index="index">
+    <ng-template ngFor [ngForOf]="rows" let-rowz="$implicit" let-index="index">
       <tr *ngIf="!(datePicker.onlyCurrentMonth && rowz[0].secondary && rowz[6].secondary)">
         <td *ngIf="datePicker.showWeeks" class="h6" class="text-center">
           <em>{{ weekNumbers[index] }}</em>
@@ -73,7 +73,7 @@ const TEMPLATE_OPTIONS: any = {
           </button>
         </td>
       </tr>
-    </template>
+    </ng-template>
   </tbody>
 </table>
   `

--- a/src/rating/rating.component.ts
+++ b/src/rating/rating.component.ts
@@ -11,10 +11,10 @@ export const RATING_CONTROL_VALUE_ACCESSOR: any = {
   selector: 'rating',
   template: `
     <span (mouseleave)="reset()" (keydown)="onKeydown($event)" tabindex="0" role="slider" aria-valuemin="0" [attr.aria-valuemax]="range.length" [attr.aria-valuenow]="value">
-      <template ngFor let-r [ngForOf]="range" let-index="index">
+      <ng-template ngFor let-r [ngForOf]="range" let-index="index">
         <span class="sr-only">({{ index < value ? '*' : ' ' }})</span>
         <i (mouseenter)="enter(index + 1)" (click)="rate(index + 1)" class="glyphicon" [ngClass]="index < value ? r.stateOn : r.stateOff" [title]="r.title" ></i>
-      </template>
+      </ng-template>
     </span>
   `,
   providers: [RATING_CONTROL_VALUE_ACCESSOR]

--- a/src/sortable/sortable.component.ts
+++ b/src/sortable/sortable.component.ts
@@ -34,11 +34,11 @@ import { DraggableItemService } from './draggable-item.service';
         (dragend)="resetActiveItem($event)"
         (dragover)="onItemDragover($event, i)"
         (dragenter)="cancelEvent($event)"
-    ><template [ngTemplateOutlet]="itemTemplate || defItemTemplate"
-  [ngOutletContext]="{item:item, index: i}"></template></div>
+    ><ng-template [ngTemplateOutlet]="itemTemplate || defItemTemplate"
+  [ngOutletContext]="{item:item, index: i}"></ng-template></div>
 </div>
 
-<template #defItemTemplate let-item="item">{{item.value}}</template>  
+<ng-template #defItemTemplate let-item="item">{{item.value}}</ng-template>  
 `,
   providers: [{
     provide: NG_VALUE_ACCESSOR,

--- a/src/spec/ng-bootstrap/popover.spec.ts
+++ b/src/spec/ng-bootstrap/popover.spec.ts
@@ -97,7 +97,7 @@ describe('popover', () => {
 
     it('should open and close a popover - default settings and content from a template', () => {
       const fixture = createTestComponent(`
-          <template #t>Hello, {{name}}!</template>
+          <ng-template #t>Hello, {{name}}!</ng-template>
           <div [popover]="t" popoverTitle="Title"></div>`);
       const directive = fixture.debugElement.query(By.directive(PopoverDirective));
       const defaultConfig = new PopoverConfig();
@@ -120,7 +120,7 @@ describe('popover', () => {
 
     it('should properly destroy TemplateRef content', () => {
       const fixture = createTestComponent(`
-          <template #t><destroyable-cmpt></destroyable-cmpt></template>
+          <ng-template #t><destroyable-cmpt></destroyable-cmpt></ng-template>
           <div [popover]="t" popoverTitle="Title"></div>`);
       const directive = fixture.debugElement.query(By.directive(PopoverDirective));
       const spyService = fixture.debugElement.injector.get(SpyService);
@@ -165,7 +165,7 @@ describe('popover', () => {
 
     it('should not leave dangling popovers in the DOM', () => {
       const fixture =
-        createTestComponent(`<template [ngIf]="show"><div popover="Great tip!" popoverTitle="Title"></div></template>`);
+        createTestComponent(`<ng-template [ngIf]="show"><div popover="Great tip!" popoverTitle="Title"></div></ng-template>`);
       const directive = fixture.debugElement.query(By.directive(PopoverDirective));
 
       directive.triggerEventHandler('click', {});
@@ -181,9 +181,9 @@ describe('popover', () => {
     });
 
     it('should properly cleanup popovers with manual triggers', () => {
-      const fixture = createTestComponent(`<template [ngIf]="show">
+      const fixture = createTestComponent(`<ng-template [ngIf]="show">
                                             <div popover="Great tip!" triggers="manual" #p="bs-popover" (mouseenter)="p.show()"></div>
-                                        </template>`);
+                                        </ng-template>`);
       const directive = fixture.debugElement.query(By.directive(PopoverDirective));
 
       directive.triggerEventHandler('mouseenter', {});

--- a/src/spec/ng-bootstrap/tooltip.spec.ts
+++ b/src/spec/ng-bootstrap/tooltip.spec.ts
@@ -72,7 +72,7 @@ describe('tooltip', () => {
     });
 
     it('should open and close a tooltip - default settings and content from a template', () => {
-      const fixture = createTestComponent(`<template #t>Hello, {{name}}!</template><div [tooltip]="t"></div>`);
+      const fixture = createTestComponent(`<ng-template #t>Hello, {{name}}!</ng-template><div [tooltip]="t"></div>`);
       const directive = fixture.debugElement.query(By.directive(TooltipDirective));
 
       directive.triggerEventHandler('mouseenter', {});
@@ -132,7 +132,7 @@ describe('tooltip', () => {
     });
 
     it('should not leave dangling tooltips in the DOM', () => {
-      const fixture = createTestComponent(`<template [ngIf]="show"><div tooltip="Great tip!"></div></template>`);
+      const fixture = createTestComponent(`<ng-template [ngIf]="show"><div tooltip="Great tip!"></div></ng-template>`);
       const directive = fixture.debugElement.query(By.directive(TooltipDirective));
 
       directive.triggerEventHandler('mouseenter', {});
@@ -146,9 +146,9 @@ describe('tooltip', () => {
 
     it('should properly cleanup tooltips with manual triggers', () => {
       const fixture = createTestComponent(`
-            <template [ngIf]="show">
+            <ng-template [ngIf]="show">
               <div tooltip="Great tip!" triggers="manual" #t="bs-tooltip" (mouseenter)="t.show()"></div>  
-            </template>`);
+            </ng-template>`);
       const directive = fixture.debugElement.query(By.directive(TooltipDirective));
 
       directive.triggerEventHandler('mouseenter', {});

--- a/src/tabs/tab-heading.directive.ts
+++ b/src/tabs/tab-heading.directive.ts
@@ -2,7 +2,7 @@ import { Directive, TemplateRef } from '@angular/core';
 
 import { TabDirective } from './tab.directive';
 
-/** Should be used to mark <template> element as a template for tab heading */
+/** Should be used to mark <ng-template> element as a template for tab heading */
 @Directive({selector: '[tabHeading]'})
 export class TabHeadingDirective {
   public templateRef:TemplateRef<any>;

--- a/src/tooltip/tooltip-container.component.ts
+++ b/src/tooltip/tooltip-container.component.ts
@@ -27,9 +27,9 @@ import { isBs3 } from '../utils/ng2-bootstrap-config';
   //     </div>
   //     <div class="tooltip-inner"
   //          *ngIf="htmlContent && isTemplate">
-  //       <template [ngTemplateOutlet]="htmlContent"
+  //       <ng-template [ngTemplateOutlet]="htmlContent"
   //                 [ngOutletContext]="{model: context}">
-  //       </template>
+  //       </ng-template>
   //     </div>
   //     <div class="tooltip-inner"
   //          *ngIf="content">

--- a/src/typeahead/typeahead-container.component.ts
+++ b/src/typeahead/typeahead-container.component.ts
@@ -11,43 +11,43 @@ import { TypeaheadMatch } from './typeahead-match.class';
   // tslint:disable-next-line
   template: `
 <!-- inject options list template -->
-<template [ngTemplateOutlet]="optionsListTemplate || (isBs4 ? bs4Template : bs3Template)"
-  [ngOutletContext]="{matches:matches, itemTemplate:itemTemplate, query:query}"></template>
+<ng-template [ngTemplateOutlet]="optionsListTemplate || (isBs4 ? bs4Template : bs3Template)"
+  [ngOutletContext]="{matches:matches, itemTemplate:itemTemplate, query:query}"></ng-template>
 
 <!-- default options item template -->
-<template #bsItemTemplate let-match="match" let-query="query"><span [innerHtml]="hightlight(match, query)"></span></template>
+<ng-template #bsItemTemplate let-match="match" let-query="query"><span [innerHtml]="hightlight(match, query)"></span></ng-template>
 
 <!-- Bootstrap 3 options list template -->
-<template #bs3Template>
+<ng-template #bs3Template>
 <ul class="dropdown-menu">
-  <template ngFor let-match let-i="index" [ngForOf]="matches">
+  <ng-template ngFor let-match let-i="index" [ngForOf]="matches">
     <li *ngIf="match.isHeader()" class="dropdown-header">{{match}}</li>
     <li *ngIf="!match.isHeader()" [class.active]="isActive(match)" (mouseenter)="selectActive(match)">
       <a href="#" (click)="selectMatch(match, $event)" tabindex="-1">
-        <template [ngTemplateOutlet]="itemTemplate || bsItemTemplate" 
-          [ngOutletContext]="{item:match.item, index:i, match:match, query:query}"></template>
+        <ng-template [ngTemplateOutlet]="itemTemplate || bsItemTemplate" 
+          [ngOutletContext]="{item:match.item, index:i, match:match, query:query}"></ng-template>
       </a>
     </li>
-  </template>
+  </ng-template>
 </ul>
-</template>
+</ng-template>
 
 <!-- Bootstrap 4 options list template -->
-<template #bs4Template >
-<template ngFor let-match let-i="index" [ngForOf]="matches">
+<ng-template #bs4Template >
+<ng-template ngFor let-match let-i="index" [ngForOf]="matches">
    <h6 *ngIf="match.isHeader()" class="dropdown-header">{{match}}</h6>
-   <template [ngIf]="!match.isHeader()">
+   <ng-template [ngIf]="!match.isHeader()">
       <button
         class="dropdown-item"
         (click)="selectMatch(match, $event)"
         (mouseenter)="selectActive(match)"
         [class.active]="isActive(match)">
-          <template [ngTemplateOutlet]="itemTemplate || bsItemTemplate" 
-            [ngOutletContext]="{item:match.item, index:i, match:match, query:query}"></template>
+          <ng-template [ngTemplateOutlet]="itemTemplate || bsItemTemplate" 
+            [ngOutletContext]="{item:match.item, index:i, match:match, query:query}"></ng-template>
       </button>
-  </template>
-</template>
-</template>
+  </ng-template>
+</ng-template>
+</ng-template>
 `,
   // tslint:disable
   host: {


### PR DESCRIPTION
So I was getting this warning in my browser console:
```
The <template> element is deprecated. Use <ng-template> instead ("
[WARNING ->]<template [ngIf]="!isClosed">
  <div [class]="'alert alert-' + type" role="alert" [ngClas
```

So I wrote+ran this against your repository and have provided it in a PR:
```
find -type f -exec sed -i 's|<template|<ng-template|g; s|</template|</ng-template|g;' {} ';'
```