### PR TITLE
fix(alert): dismissibleChange emits boolean values

### DIFF
--- a/src/alert/alert.component.ts
+++ b/src/alert/alert.component.ts
@@ -34,7 +34,7 @@ export class AlertComponent implements OnInit {
 
   public isClosed: boolean = false;
   public classes: string = '';
-  public dismissibleChange: EventEmitter<string> = new EventEmitter();
+  public dismissibleChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   public constructor(_config: AlertConfig) {
     Object.assign(this, _config);


### PR DESCRIPTION
`dismissibleChange` is used with `.subscribe((dismissible: boolean) => { ... })` but declared as `EventEmitter<string>`