### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To enable bootstrap 4 theme templates in ngx-bootstrap, please read
 
 # Usage & Demo
 
-Main source of API documentation and usage scenarious available here: 
+Main source of API documentation and usage scenarios available here: 
 [http://valor-software.github.io/ngx-bootstrap/](http://valor-software.github.io/ngx-bootstrap/)
 
 # API


### PR DESCRIPTION
The same typo exists on http://valor-software.com/ngx-bootstrap/

If the readme fixes it there as well, ignore.