### PR TITLE
Fix(typeahead): show available choices onFocus when minLength == 0

### DIFF
--- a/src/spec/typeahead.directive.spec.ts
+++ b/src/spec/typeahead.directive.spec.ts
@@ -186,5 +186,58 @@ describe('Directive: Typeahead', () => {
       fixture.detectChanges();
     });
   });
+  
+  describe('onFocus', () => {
+    beforeEach(fakeAsync(() => {
+ 
+    }));
+
+    it('should result in a total of 2 matches, when minLength === 0', fakeAsync(() => {
+	  expect(directive).toBeDefined();
+	  
+	  directive.typeaheadMinLength = 0;
+      fixture.detectChanges();
+      tick(100);
+	  
+	  expect(directive.typeaheadMinLength).toBe(0);
+	  directive.onFocus();
+	  
+	  tick(100);
+	  
+	  expect(directive.matches.length).toBe(2);
+    }));	
+	
+    it('should result in a total of 2 matches, when minLength === \"0\"', fakeAsync(() => {
+	  expect(directive).toBeDefined();
+	  
+	  directive.typeaheadMinLength = '0';
+      fixture.detectChanges();
+      tick(100);
+	  
+	  expect(directive.typeaheadMinLength).toBe('0');
+	  directive.onFocus();
+	  
+	  tick(100);
+	  
+	  expect(directive.matches.length).toBe(2);
+    }));
+	
+    it('should do nothing, when minLength > 0', fakeAsync(() => {
+	  expect(directive).toBeDefined();
+	  
+	  directive.typeaheadMinLength = 1;
+      fixture.detectChanges();
+      tick(100);
+	  
+	  expect(directive.typeaheadMinLength).toBe(1);
+	  directive.onFocus();
+	  
+	  tick(100);
+	  
+	  expect(directive.matches).toBeUndefined();
+    }));
+	
+	
+  });
 
 });

--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -134,7 +134,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
 
   @HostListener('focus')
   public onFocus(): void {
-    if (this.typeaheadMinLength === 0) {
+    if (this.typeaheadMinLength == 0) {
       this.typeaheadLoading.emit(true);
       this.keyUpEventEmitter.emit('');
     }


### PR DESCRIPTION
Fixes #1559 

Currently typeahead does not show list on focus when typeaheadMinLength="0" even is such behaviour is documented.

onFocus method is comparing minLength with 0, while the angular sets input property to string '0' and no event is emitted.

Fixed the issue by replacing === with == in the comparison.