### PR TITLE
feat(modals): add support for nested modals (fix scroll)

### DIFF
--- a/demo/src/app/components/+modal/demos/index.ts
+++ b/demo/src/app/components/+modal/demos/index.ts
@@ -2,12 +2,15 @@ import { DemoModalSizesComponent } from './sizes/sizes';
 import { DemoModalStaticComponent } from './static/static';
 import { DemoModalChildComponent } from './child/child';
 import { DemoAutoShownModalComponent } from './auto-shown/auto-shown';
+import { DemoNestedDropdownsComponent } from '../../+dropdown/demos/nested-dropdowns/nested-dropdowns';
+import { DemoModalNestedComponent } from './nested/nested';
 
 export const DEMO_COMPONENTS = [
   DemoModalSizesComponent,
   DemoModalChildComponent,
   DemoModalStaticComponent,
-  DemoAutoShownModalComponent
+  DemoAutoShownModalComponent,
+  DemoModalNestedComponent
 ];
 
 export const DEMOS = {
@@ -18,6 +21,10 @@ export const DEMOS = {
   child: {
     component: require('!!raw-loader?lang=typescript!./child/child.ts'),
     html: require('!!raw-loader?lang=markup!./child/child.html')
+  },
+  nested: {
+    component: require('!!raw-loader?lang=typescript!./nested/nested.ts'),
+    html: require('!!raw-loader?lang=markup!./nested/nested.html')
   },
   staticModal: {
     component: require('!!raw-loader?lang=typescript!./static/static.ts'),

--- a/demo/src/app/components/+modal/demos/nested/nested.html
+++ b/demo/src/app/components/+modal/demos/nested/nested.html
@@ -1,0 +1,50 @@
+<button type="button" class="btn btn-primary" (click)="parentModal.show()">Open parent modal</button>
+<div class="modal fade" bsModal #parentModal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title pull-left">First modal</h4>
+        <button type="button" class="close pull-right" aria-label="Close" (click)="parentModal.hide()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <button type="button" class="btn btn-primary" (click)="childModal.show()">Open second modal</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" bsModal #childModal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title pull-left">Second modal</h4>
+        <button type="button" class="close pull-right" aria-label="Close" (click)="childModal.hide()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        This is static modal <br>
+        <button type="button" class="btn btn-primary" (click)="childModall.show()">Open third modal</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" bsModal #childModall="bs-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title pull-left">Third modal</h4>
+        <button type="button" class="close pull-right" aria-label="Close" (click)="childModal.hide()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        This is static modal <br>
+        Click <b>&times;</b> to close modal.
+      </div>
+    </div>
+  </div>
+</div>

--- a/demo/src/app/components/+modal/demos/nested/nested.html
+++ b/demo/src/app/components/+modal/demos/nested/nested.html
@@ -26,18 +26,18 @@
       </div>
       <div class="modal-body">
         This is static modal <br>
-        <button type="button" class="btn btn-primary" (click)="childModall.show()">Open third modal</button>
+        <button type="button" class="btn btn-primary" (click)="thirdModal.show()">Open third modal</button>
       </div>
     </div>
   </div>
 </div>
 
-<div class="modal fade" bsModal #childModall="bs-modal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade" bsModal #thirdModal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog modal-sm">
     <div class="modal-content">
       <div class="modal-header">
         <h4 class="modal-title pull-left">Third modal</h4>
-        <button type="button" class="close pull-right" aria-label="Close" (click)="childModal.hide()">
+        <button type="button" class="close pull-right" aria-label="Close" (click)="thirdModal.hide()">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>

--- a/demo/src/app/components/+modal/demos/nested/nested.ts
+++ b/demo/src/app/components/+modal/demos/nested/nested.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'demo-modal-nested',
+  templateUrl: './nested.html'
+})
+export class DemoModalNestedComponent {
+
+}

--- a/demo/src/app/components/+modal/modal-section.component.ts
+++ b/demo/src/app/components/+modal/modal-section.component.ts
@@ -18,6 +18,7 @@ let titleDoc = require('html-loader!markdown-loader!./docs/title.md');
         <li><a routerLink="." fragment="static">Static modal</a></li>
         <li><a routerLink="." fragment="sizes">Optional sizes</a></li>
         <li><a routerLink="." fragment="child">Child modal</a></li>
+        <li><a routerLink="." fragment="nested">Nested modals</a></li>
         <li><a routerLink="." fragment="auto-shown">Auto shown modal</a></li>
       </ul>
     </li>
@@ -50,6 +51,12 @@ let titleDoc = require('html-loader!markdown-loader!./docs/title.md');
   <p>Control modal from parent component</p>
   <ng-sample-box [ts]="demos.child.component" [html]="demos.child.html">
     <demo-modal-child></demo-modal-child>
+  </ng-sample-box>
+
+  <h2 routerLink="." fragment="nested" id="nested">Nested modals</h2>
+  <p>Open a modal from another modal</p>
+  <ng-sample-box [ts]="demos.nested.component" [html]="demos.nested.html">
+    <demo-modal-nested></demo-modal-nested>
   </ng-sample-box>
 
   <h2 routerLink="." fragment="auto-shown" id="auto-shown">Auto shown modal</h2>

--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -82,6 +82,8 @@ export class ModalDirective implements AfterViewInit, OnDestroy {
   // todo: implement _dialog
   private _dialog: any;
 
+  private isNested: boolean = false;
+
   @HostListener('click', ['$event'])
   public onClick(event: any): void {
     if (this.config.ignoreBackdropClick || this.config.backdrop === 'static' || event.target !== this._element.nativeElement) {
@@ -143,7 +145,11 @@ export class ModalDirective implements AfterViewInit, OnDestroy {
     this.setScrollbar();
 
     if (document && document.body) {
-      this._renderer.setElementClass(document.body, ClassName.OPEN, true);
+      if (document.body.classList.contains(ClassName.OPEN)) {
+        this.isNested = true;
+      } else {
+        this._renderer.setElementClass(document.body, ClassName.OPEN, true);
+      }
     }
 
     this.showBackdrop(() => {
@@ -233,11 +239,13 @@ export class ModalDirective implements AfterViewInit, OnDestroy {
     this._renderer.setElementAttribute(this._element.nativeElement, 'aria-hidden', 'true');
     this._renderer.setElementStyle(this._element.nativeElement, 'display', 'none');
     this.showBackdrop(() => {
-      if (document && document.body) {
-        this._renderer.setElementClass(document.body, ClassName.OPEN, false);
+      if (!this.isNested) {
+        if (document && document.body) {
+          this._renderer.setElementClass(document.body, ClassName.OPEN, false);
+        }
+        this.resetScrollbar();
       }
       this.resetAdjustments();
-      this.resetScrollbar();
       this.onHidden.emit(this);
     });
   }


### PR DESCRIPTION
Twitter bootstrap (and so ngx-boostrap) doesn't officialy support nested modals.
You can however display nested modal but at least one issue appears:
At first modal you close, scroll events and scrollbar go back to the page, so
you can't scroll modals that are still displayed.

I propose to improve it with following modifications in modal component:
- at show, check if 'modal open' class is already attached to document body and
  set `isNested` boolean accordingly
- at hide, if nested, do not remove 'modal open' class and do not reset
  scrollbar.

Related to:
valor-software/ngx-bootstrap#896
valor-software/ngx-bootstrap#1691