### PR TITLE
fix(popover): prevent ng router active link double ngOnInit issue

### DIFF
--- a/src/popover/popover.directive.ts
+++ b/src/popover/popover.directive.ts
@@ -54,6 +54,7 @@ export class PopoverDirective implements OnInit, OnDestroy {
   @Output() public onHidden: EventEmitter<any>;
 
   private _popover: ComponentLoader<PopoverContainerComponent>;
+  private _isInited = false;
 
   public constructor(_elementRef: ElementRef,
                      _renderer: Renderer,
@@ -113,6 +114,12 @@ export class PopoverDirective implements OnInit, OnDestroy {
   }
 
   public ngOnInit(): any {
+    // fix: seems there are an issue with `routerLinkActive`
+    // which result in duplicated call ngOnInit without call to ngOnDestroy
+    // read more: https://github.com/valor-software/ngx-bootstrap/issues/1885
+    if (this._isInited) { return; }
+    this._isInited = true;
+
     this._popover.listen({
       triggers: this.triggers,
       show: () => this.show()


### PR DESCRIPTION
Same issue we had with the Dropdown directive. For some reason, the ngOnInit method is called twice.