### PR TITLE
Remove dynamic tab with dynamic content and after add the same tab.

### DIFF
--- a/src/tabs/tabset.component.ts
+++ b/src/tabs/tabset.component.ts
@@ -94,7 +94,7 @@ export class TabsetComponent implements OnDestroy {
     }
     this.tabs.splice(index, 1);
     if(tab.elementRef.nativeElement && tab.elementRef.nativeElement.remove) {
-      tab.elementRef.nativeElement.remove();
+      tab.elementRef.nativeElement.dispose();
     }
   }
 


### PR DESCRIPTION
Fixing the problem when i remove a dynamic tab with dynamic content, and add this tab again to the view.

Ex:
`<tab *ngFor="let tabz of tabs"
                 [heading]="tabz.title"
                 [removable]="true">
                <div>
                    <app-custom-component></app-custom-component>
                </div>
            </tab>`

After remove some tab and try to add the tab to tabz array, the component doesn't appear.
