### PR TITLE
When `dismissible`, add missing `alert-dismissible` CSS class that is used in Bootstrap

### DIFF
--- a/src/alert/alert.component.ts
+++ b/src/alert/alert.component.ts
@@ -6,7 +6,7 @@ import { OnChange } from '../utils/decorators';
   selector: 'alert,ngx-alert',
   template: `
 <template [ngIf]="!isClosed">
-  <div [class]="'alert alert-' + type" role="alert" [ngClass]="classes">
+  <div [class]="'alert alert-' + type + (dismissible ? ' alert-dismissible' : '')" role="alert" [ngClass]="classes">
     <template [ngIf]="dismissible">
       <button type="button" class="close" aria-label="Close" (click)="close()">
         <span aria-hidden="true">&times;</span>


### PR DESCRIPTION
When 'dismissible' the alert is missing the .alert-dismissible CSS class that is used in Bootstrap

Angular: 4.0.0
ngx-bootstrap: 1.7.1
Bootstrap: 4.0.0-alpha.6