### PR TITLE
fix(typeahead): Fix crash on Firefox and `contenteditable` input

### DIFF
--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -118,11 +118,15 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
     }
 
     // For `<input>`s, use the `value` property. For others that don't have a
-    // `value` (such as `<span contenteditable="true">`, use `innerText`.
+    // `value` (such as `<span contenteditable="true">`), use either
+    // `textContent` or `innerText` (depending on which one is supported, i.e.
+    // Firefox or IE).
     const value = e.target.value !== undefined
       ? e.target.value
-      : e.target.innerText;
-    if (value.trim().length >= this.typeaheadMinLength) {
+      : e.target.textContent !== undefined
+        ? e.target.textContent
+        : e.target.innerText;
+    if (value && value.trim().length >= this.typeaheadMinLength) {
       this.typeaheadLoading.emit(true);
       this.keyUpEventEmitter.emit(e.target.value);
     } else {


### PR DESCRIPTION
When using the typeahead directive on a `contenteditable` input, crashes can happen on Firefox:

    TypeError
    n.target.innerText is undefined

According to many sources \[1\] \[2\] \[3\], `innerText` should only be used on old browsers where `textContent` in not defined (e.g. Internet Explorer). On newer browsers that abide by standards, `textContent` is the right property to use to avoid problems.

\[1\]: https://stackoverflow.com/a/22990890
\[2\]: https://teamtreehouse.com/community/firefox-innertext-undefined-teachers-note
\[3\]: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent