### PR TITLE
fix Template parse warnings

### DIFF
--- a/src/datepicker/daypicker.component.ts
+++ b/src/datepicker/daypicker.component.ts
@@ -58,7 +58,7 @@ const TEMPLATE_OPTIONS: any = {
     </tr>
   </thead>
   <tbody>
-    <template ngFor [ngForOf]="rows" let-rowz="$implicit" let-index="index">
+    <ng-template ngFor [ngForOf]="rows" let-rowz="$implicit" let-index="index">
       <tr *ngIf="!(datePicker.onlyCurrentMonth && rowz[0].secondary && rowz[6].secondary)">
         <td *ngIf="datePicker.showWeeks" class="h6" class="text-center">
           <em>{{ weekNumbers[index] }}</em>
@@ -73,7 +73,7 @@ const TEMPLATE_OPTIONS: any = {
           </button>
         </td>
       </tr>
-    </template>
+    </ng-template>
   </tbody>
 </table>
   `


### PR DESCRIPTION
core.es5.js:3054 Template parse warnings:
The <template> element is deprecated. Use <ng-template> instead ("
  </thead>
  <tbody>
    [WARNING ->]<template ngFor [ngForOf]="rows" let-rowz="$implicit" let-index="index">
      <tr *ngIf="!(datePicke"): ng:///DatepickerModule/DayPickerComponent.html@38:4