### PR TITLE
Typehead: getValueFromObject() crash in case of null values

### DIFF
--- a/src/spec/typeahead.directive.spec.ts
+++ b/src/spec/typeahead.directive.spec.ts
@@ -132,6 +132,16 @@ describe('Directive: Typeahead', () => {
 
       expect(directive.matches.length).toBe(0);
     }));
+
+    it('should not display null item', fakeAsync(() => {
+      component.states.push({id: 3, name: null, region: 'West'});
+      inputElement.value = 'Ala';
+      fireEvent(inputElement, 'keyup');
+      fixture.detectChanges();
+      tick(100);
+
+      expect(directive.matches.length).toBe(2);
+    }));
   });
 
   describe('onChange grouped', () => {

--- a/src/typeahead/typeahead-utils.ts
+++ b/src/typeahead/typeahead-utils.ts
@@ -55,5 +55,6 @@ export function getValueFromObject(object: any, option: string): string {
       object = object[property];
     }
   }
+  if (!object) return "";
   return object.toString();
 }


### PR DESCRIPTION
getValueFromObject() last statement return object.toString() crashes if object is null.
Just check object for null and return empty string