### PR TITLE
Make the typeahead results show when typeaheadMinLength is 0 and the search string is empty

### DIFF
--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -126,7 +126,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
       : e.target.textContent !== undefined
         ? e.target.textContent
         : e.target.innerText;
-    if (value && value.trim().length >= this.typeaheadMinLength) {
+    if (this.typeaheadMinLength === 0 || (value && value.trim().length >= this.typeaheadMinLength)) {
       this.typeaheadLoading.emit(true);
       this.keyUpEventEmitter.emit(e.target.value);
     } else {

--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -126,7 +126,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
       : e.target.textContent !== undefined
         ? e.target.textContent
         : e.target.innerText;
-    if (this.typeaheadMinLength === 0 || (value && value.trim().length >= this.typeaheadMinLength)) {
+    if (value != null && value.trim().length >= this.typeaheadMinLength) {
       this.typeaheadLoading.emit(true);
       this.keyUpEventEmitter.emit(e.target.value);
     } else {


### PR DESCRIPTION
The != null comparison makes sure no null or undefined values are being emitted, while allowing for the empty string when the typeaheadMinLength is 0. Current behavior is to show the complete list on focus when typeaheadMinLength is 0, but when clearing the input value, it does not show the list.