### PR TITLE
Add `onDrop` Event to sortable

### DIFF
--- a/demo/src/app/components/+sortable/demos/index.ts
+++ b/demo/src/app/components/+sortable/demos/index.ts
@@ -1,11 +1,13 @@
 import { ComplexDatamodelDemoComponent } from './complex-datamodel/complex-datamodel.component';
 import { SimpleItemsDemoComponent } from './simple-items/simple-items.component';
 import { CustomItemTemplateDemoComponent } from './custom-item-template/custom-item-template';
+import { OnDropEventComponent } from './on-drop-event/on-drop-event.component';
 
 export const DEMO_COMPONENTS = [
   SimpleItemsDemoComponent,
   ComplexDatamodelDemoComponent,
-  CustomItemTemplateDemoComponent
+  CustomItemTemplateDemoComponent,
+  OnDropEventComponent
 ];
 
 export const DEMOS = {
@@ -20,5 +22,9 @@ export const DEMOS = {
   itemTemplate: {
     component: require('!!raw-loader?lang=typescript!./custom-item-template/custom-item-template.ts'),
     html: require('!!raw-loader?lang=markup!./custom-item-template/custom-item-template.html')
+  },
+  onDropEvent: {
+    component: require('!!raw-loader?lang=typescript!./on-drop-event/on-drop-event.component.ts'),
+    html: require('!!raw-loader?lang=markup!./on-drop-event/on-drop-event.component.html')
   }
 };

--- a/demo/src/app/components/+sortable/demos/on-drop-event/on-drop-event.component.html
+++ b/demo/src/app/components/+sortable/demos/on-drop-event/on-drop-event.component.html
@@ -1,0 +1,27 @@
+<div class="col-xs-6 col-md-3">
+  <bs-sortable
+    [(ngModel)]="itemStringsLeft"
+    (onDrop)="onDropLeft($event)"
+    itemClass="sortable-item"
+    itemActiveClass="sortable-item-active"
+    placeholderItem="Drag here"
+    placeholderClass="placeholderStyle"
+    wrapperClass="sortable-wrapper"
+  ></bs-sortable>
+  <pre>model: {{ itemStringsLeft | json }}</pre>
+</div>
+<div class="col-xs-6 col-md-3">
+  <bs-sortable
+    [(ngModel)]="itemStringsRight"
+    (onDrop)="onDropRight($event)"
+    itemClass="sortable-item"
+    itemActiveClass="sortable-item-active"
+    placeholderItem="Drag here"
+    placeholderClass="sortable-item"
+    wrapperClass="sortable-wrapper"
+  ></bs-sortable>
+  <pre>model: {{ itemStringsRight | json }}</pre>
+</div>
+<div class="col-xs-12 col-md-6">
+  <pre>dropEvents: {{ dropEvents | json }}</pre>
+</div>

--- a/demo/src/app/components/+sortable/demos/on-drop-event/on-drop-event.component.ts
+++ b/demo/src/app/components/+sortable/demos/on-drop-event/on-drop-event.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'on-drop-event-demo',
+  templateUrl: './on-drop-event.component.html'
+})
+export class OnDropEventComponent {
+  public dropEvents: Array<any> = [];
+
+  public itemStringsLeft: any[] = [
+    'Windstorm',
+    'Bombasto',
+    'Magneta',
+    'Tornado'
+  ];
+
+  public itemStringsRight: any[] = [
+    'Mr. O',
+    'Tomato'
+  ];
+
+  onDropRight(event) {
+    this.dropEvents.push("dropped item in right list (length: " + event.length + ")");
+  }
+
+  onDropLeft(event) {
+    this.dropEvents.push("dropped item in left list (length: " + event.length + ")");
+  }
+}

--- a/demo/src/app/components/+sortable/sortable-section.component.html
+++ b/demo/src/app/components/+sortable/sortable-section.component.html
@@ -29,6 +29,7 @@
         <li><a routerLink="." fragment="stringItems">String items</a></li>
         <li><a routerLink="." fragment="complexDatamodel">Complex datamodel</a></li>
         <li><a routerLink="." fragment="itemTemplate">Custom item template</a></li>
+        <li><a routerLink="." fragment="onDropEvent">On Drop Event</a></li>
       </ul>
     </li>
     <li><a routerLink="." fragment="api-reference">API Reference</a>
@@ -58,6 +59,12 @@
   <ng-sample-box [ts]="demos.itemTemplate.component" [html]="demos.itemTemplate.html">
     <custom-item-template-demo></custom-item-template-demo>
   </ng-sample-box>
+
+  <h2 routerLink="." fragment="onDropEvent" id="onDropEvent">On Drop Event:</h2>
+  <ng-sample-box [ts]="demos.onDropEvent.component" [html]="demos.onDropEvent.html">
+    <on-drop-event-demo></on-drop-event-demo>
+  </ng-sample-box>
+
 
   <h2 routerLink="." fragment="api-reference" id="api-reference">API Reference</h2>
   <ng-api-doc id="sortable-component" directive="SortableComponent"></ng-api-doc>

--- a/demo/src/ng-api-doc.ts
+++ b/demo/src/ng-api-doc.ts
@@ -68,15 +68,15 @@ export const ngdoc: any = {
     "selector": "alert,ngx-alert",
     "inputs": [
       {
+        "name": "dismissOnTimeout",
+        "type": "string | number",
+        "description": "<p>Number in milliseconds, after which alert will be closed </p>\n"
+      },
+      {
         "name": "dismissible",
         "defaultValue": "false",
         "type": "boolean",
         "description": "<p>If set, displays an inline &quot;Close&quot; button </p>\n"
-      },
-      {
-        "name": "dismissOnTimeout",
-        "type": "string | number",
-        "description": "<p>Number in milliseconds, after which alert will be closed </p>\n"
       },
       {
         "name": "type",
@@ -112,16 +112,16 @@ export const ngdoc: any = {
     "methods": [],
     "properties": [
       {
-        "name": "dismissible",
-        "defaultValue": "false",
-        "type": "boolean",
-        "description": "<p>is alerts are dismissible by default </p>\n"
-      },
-      {
         "name": "dismissOnTimeout",
         "defaultValue": "undefined",
         "type": "number",
         "description": "<p>default time before alert will dismiss </p>\n"
+      },
+      {
+        "name": "dismissible",
+        "defaultValue": "false",
+        "type": "boolean",
+        "description": "<p>is alerts are dismissible by default </p>\n"
       },
       {
         "name": "type",
@@ -1673,6 +1673,10 @@ export const ngdoc: any = {
       {
         "name": "onChange",
         "description": "<p>fired on array change (reordering, insert, remove), same as <code>ngModelChange</code>.\n Returns new items collection as a payload.</p>\n"
+      },
+      {
+        "name": "onDrop",
+        "description": "<p>fired on drop of an element.\n Returns new items collection as a payload.</p>\n"
       }
     ],
     "properties": [],

--- a/src/sortable/sortable.component.ts
+++ b/src/sortable/sortable.component.ts
@@ -16,7 +16,7 @@ import { DraggableItemService } from './draggable-item.service';
     [ngStyle]="wrapperStyle"
     (dragover)="cancelEvent($event)"
     (dragenter)="cancelEvent($event)"
-    (drop)="resetActiveItem($event)"
+    (drop)="onDropped($event)"
     (mouseleave)="resetActiveItem($event)">
   <div
         *ngIf="showPlaceholder"
@@ -38,7 +38,7 @@ import { DraggableItemService } from './draggable-item.service';
   [ngOutletContext]="{item:item, index: i}"></template></div>
 </div>
 
-<template #defItemTemplate let-item="item">{{item.value}}</template>  
+<template #defItemTemplate let-item="item">{{item.value}}</template>
 `,
   providers: [{
     provide: NG_VALUE_ACCESSOR,
@@ -88,6 +88,11 @@ export class SortableComponent implements ControlValueAccessor {
    */
   @Output() public onChange: EventEmitter<any[]> = new EventEmitter<any[]>();
 
+  /** fired on drop of an element.
+   *  Returns new items collection as a payload.
+   */
+  @Output() public onDrop: EventEmitter<any[]> = new EventEmitter<any[]>();
+
   public showPlaceholder: boolean = false;
   public activeItem: number = -1;
 
@@ -113,7 +118,7 @@ export class SortableComponent implements ControlValueAccessor {
     this.transfer = transfer;
     this.currentZoneIndex = SortableComponent.globalZoneIndex++;
     this.transfer.onCaptureItem()
-      .subscribe((item: DraggableItem) => this.onDrop(item));
+      .subscribe((item: DraggableItem) => this.onTransfer(item));
   }
 
   public onItemDragstart(event: DragEvent, item: SortableItem, i: number): void {
@@ -166,7 +171,7 @@ export class SortableComponent implements ControlValueAccessor {
     event.preventDefault();
   }
 
-  public onDrop(item: DraggableItem): void {
+  public onTransfer(item: DraggableItem): void {
     if (item &&
       item.overZoneIndex !== this.currentZoneIndex &&
       item.lastZoneIndex === this.currentZoneIndex
@@ -175,6 +180,11 @@ export class SortableComponent implements ControlValueAccessor {
       this.updatePlaceholderState();
     }
     this.resetActiveItem(undefined);
+  }
+
+  public onDropped(event: DragEvent): void {
+    this.onDrop.emit(this.items);
+    this.resetActiveItem(event);
   }
 
   public resetActiveItem(event: DragEvent): void {

--- a/src/spec/sortable.component.spec.ts
+++ b/src/spec/sortable.component.spec.ts
@@ -94,6 +94,7 @@ describe('Component: Sortable', () => {
     let spyCaptureItem: jasmine.Spy;
     let sort1ZoneNumber: number;
     let spyPreventDefault: jasmine.Spy;
+    let spyOnTransfer: jasmine.Spy;
     let spyOnDrop: jasmine.Spy;
 
     beforeEach(inject([DraggableItemService], (service: DraggableItemService) => {
@@ -106,7 +107,7 @@ describe('Component: Sortable', () => {
       spyGetItem = spyOn(transfer, 'getItem').and.returnValue(draggableItem);
       spyCaptureItem = spyOn(transfer, 'captureItem').and.returnValue(draggableItem);
       spyPreventDefault = spyOn(event, 'preventDefault');
-      spyOnDrop = spyOn(sort1, 'onDrop').and.callThrough();
+      spyOnTransfer = spyOn(sort1, 'onTransfer').and.callThrough();
     }));
 
     it('should pass dragged item to transfer', () => {
@@ -152,19 +153,19 @@ describe('Component: Sortable', () => {
       expect(spyPreventDefault).not.toHaveBeenCalled();
     });
 
-    it('should remove item if it was captured or dropped in another continer', () => {
+    it('should remove item if it was captured or dropped in another container', () => {
       // arrange
       draggableItem.overZoneIndex = -1;
       // act
-      sort1.onDrop(draggableItem);
+      sort1.onTransfer(draggableItem);
       // assert
       expect(spyOnChanged).toHaveBeenCalledWith([ HEROES[1], HEROES[2], HEROES[3] ]);
     });
 
-    it('shouldn NOT remove item if it was dropped in the same continer', () => {
+    it('shouldn NOT remove item if it was dropped in the same container', () => {
       // arrange
       // act
-      sort1.onDrop(draggableItem);
+      sort1.onTransfer(draggableItem);
       // assert
       expect(spyOnChanged).not.toHaveBeenCalled();
     });
@@ -239,7 +240,7 @@ describe('Component: Sortable', () => {
       // act
       let capturedItem = transfer.captureItem(-1, 0);
       // assert
-      transfer.onCaptureItem().subscribe(() => expect(spyOnDrop).toHaveBeenCalledWith(capturedItem));
+      transfer.onCaptureItem().subscribe(() => expect(spyOnTransfer).toHaveBeenCalledWith(capturedItem));
     }));
 
     it('should remove item when it is over an another container', fakeAsync(() => {


### PR DESCRIPTION
I have a collection with an order which should be synced with the server. The `onChange` event is fired continuously on dragging and does not fullfill my needs.

That is why i introduced the `onDrop` callback to be notified whenever an element is dropped.