### PR TITLE
fix(alert): remove template deprecated warning

### DIFF
--- a/src/alert/alert.component.ts
+++ b/src/alert/alert.component.ts
@@ -6,12 +6,10 @@ import { OnChange } from '../utils/decorators';
   selector: 'alert,ngx-alert',
   template: `
   <div *ngIf="!isClosed" [class]="'alert alert-' + type" role="alert" [ngClass]="classes">
-    <template [ngIf]="dismissible">
-      <button type="button" class="close" aria-label="Close" (click)="close()">
+      <button *ngIf="dismissible" type="button" class="close" aria-label="Close" (click)="close()">
         <span aria-hidden="true">&times;</span>
         <span class="sr-only">Close</span>
       </button>
-    </template>
     <ng-content></ng-content>
   </div>
   `

--- a/src/alert/alert.component.ts
+++ b/src/alert/alert.component.ts
@@ -5,13 +5,17 @@ import { OnChange } from '../utils/decorators';
 @Component({
   selector: 'alert,ngx-alert',
   template: `
-  <div *ngIf="!isClosed" [class]="'alert alert-' + type" role="alert" [ngClass]="classes">
-      <button *ngIf="dismissible" type="button" class="close" aria-label="Close" (click)="close()">
+<ng-template [ngIf]="!isClosed">
+  <div [class]="'alert alert-' + type" role="alert" [ngClass]="classes">
+    <ng-template [ngIf]="dismissible">
+      <button type="button" class="close" aria-label="Close" (click)="close()">
         <span aria-hidden="true">&times;</span>
         <span class="sr-only">Close</span>
       </button>
+    </ng-template>
     <ng-content></ng-content>
   </div>
+</ng-template>
   `
 })
 export class AlertComponent implements OnInit {

--- a/src/alert/alert.component.ts
+++ b/src/alert/alert.component.ts
@@ -5,8 +5,7 @@ import { OnChange } from '../utils/decorators';
 @Component({
   selector: 'alert,ngx-alert',
   template: `
-<template [ngIf]="!isClosed">
-  <div [class]="'alert alert-' + type" role="alert" [ngClass]="classes">
+  <div *ngIf="!isClosed" [class]="'alert alert-' + type" role="alert" [ngClass]="classes">
     <template [ngIf]="dismissible">
       <button type="button" class="close" aria-label="Close" (click)="close()">
         <span aria-hidden="true">&times;</span>
@@ -15,7 +14,6 @@ import { OnChange } from '../utils/decorators';
     </template>
     <ng-content></ng-content>
   </div>
-</template>
   `
 })
 export class AlertComponent implements OnInit {


### PR DESCRIPTION
use `ng-template` instead of `template`-tag to fix deprecation warning 