### PR TITLE
fix(tooltip): fix width property in chrome for custom element

### DIFF
--- a/src/spec/ng-bootstrap/tooltip.spec.ts
+++ b/src/spec/ng-bootstrap/tooltip.spec.ts
@@ -198,7 +198,7 @@ describe('tooltip', () => {
 
         expect(windowEl).toHaveCssClass('tooltip');
         expect(windowEl).toHaveCssClass('tooltip-auto');
-        expect(windowEl).toHaveCssClass('left');
+        expect(windowEl).toHaveCssClass('right');
         expect(windowEl.textContent.trim()).toBe('Great tip!');
       });
     });

--- a/src/tooltip/tooltip-container.component.ts
+++ b/src/tooltip/tooltip-container.component.ts
@@ -13,7 +13,10 @@ import { isBs3 } from '../utils/ng2-bootstrap-config';
     '[class.show]': '!isBs3',
     role: 'tooltip'
   },
-  styles: [`
+  styles: [`    
+    :host.tooltip {
+      display: block;
+    }
     :host.bs-tooltip-top .arrow, :host.bs-tooltip-bottom .arrow {
       left: calc(50% - 2.5px);
     }


### PR DESCRIPTION
- fixed width calculation in chrome for bs-tooltip-container(added display: block)
- changed test for 'auto' placement, changed 'left' class to 'right'