### PR TITLE
[Fixed bug]: Added null check on the parentElement in focusOtherModal()

### DIFF
--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -329,6 +329,7 @@ export class ModalDirective implements AfterViewInit, OnDestroy {
   // }
 
   protected focusOtherModal() {
+    if (this._element.nativeElement.parentElement == null) return;
     const otherOpenedModals = this._element.nativeElement.parentElement.querySelectorAll('.in[bsModal]');
     if (!otherOpenedModals.length) {
       return;


### PR DESCRIPTION
 If the modal is created without parent, the console will display error on closing function:

```
  modal.component.js:278 Uncaught TypeError: Cannot read property 'querySelectorAll' of null
    at ModalDirective.webpackJsonp.../../../../ngx-bootstrap/modal/modal.component.js.ModalDirective.focusOtherModal (modal.component.js:278)
    at modal.component.js:208
    at callbackRemove (modal.component.js:237)
    at ZoneDelegate.webpackJsonp.../../../../zone.js/dist/zone.js.ZoneDelegate.invokeTask (zone.js:424)
    at Object.onInvokeTask (core.es5.js:3881)
    at ZoneDelegate.webpackJsonp.../../../../zone.js/dist/zone.js.ZoneDelegate.invokeTask (zone.js:423)
    at Zone.webpackJsonp.../../../../zone.js/dist/zone.js.Zone.runTask (zone.js:191)
    at ZoneTask.invoke (zone.js:486)
    at timer (zone.js:1512)

```