### PR TITLE
Use !default for SASS variables

### DIFF
--- a/src/datepicker/utils/scss/variables.scss
+++ b/src/datepicker/utils/scss/variables.scss
@@ -1,30 +1,30 @@
-$main-bg:         #fff;
-$custom-range-bg: #eee;
+$main-bg:         #fff !default;
+$custom-range-bg: #eee !default;
 
-$main-box-shadow: #aaa;
+$main-box-shadow: #aaa !default;
 
-$font-color-01:   #fff;
-$font-color-02:   #9aaec1;
-$font-color-03:   #54708b;
+$font-color-01:   #fff !default;
+$font-color-02:   #9aaec1 !default;
+$font-color-03:   #54708b !default;
 
-$border-color:    #e9edf0;
-$highlighted:     #e9edf0;
+$border-color:    #e9edf0 !default;
+$highlighted:     #e9edf0 !default;
 
-$btn-bg:          #e9edf0;
-$btn-bg-hover:    #d5dadd;
+$btn-bg:          #e9edf0 !default;
+$btn-bg-hover:    #d5dadd !default;
 
-$btn-bg2:         #9aaec1;
-$btn-bg2-hover:   #54708b;
+$btn-bg2:         #9aaec1 !default;
+$btn-bg2-hover:   #54708b !default;
 
-$theme-gray:      #777;
-$theme-green:     #5cb85c;
-$theme-blue:      #5bc0de;
-$theme-dark-blue: #337ab7;
-$theme-red:       #d9534f;
-$theme-orange:    #f0ad4e;
+$theme-gray:      #777 !default;
+$theme-green:     #5cb85c !default;
+$theme-blue:      #5bc0de !default;
+$theme-dark-blue: #337ab7 !default;
+$theme-red:       #d9534f !default;
+$theme-orange:    #f0ad4e !default;
 
-$disabled-background:  rgba(221, 221, 221, 0.3);
-$disabled-color:       #f5f5f5;
+$disabled-background:  rgba(221, 221, 221, 0.3) !default;
+$disabled-color:       #f5f5f5 !default;
 
 $theme-list: (
   'default': $theme-gray,
@@ -33,4 +33,4 @@ $theme-list: (
   'dark-blue': $theme-dark-blue,
   'red': $theme-red,
   'orange': $theme-orange,
-);
+) !default;


### PR DESCRIPTION
In order to be able to override the variables in SASS, each variable declaration should have a `!default` flag (http://sass-lang.com/documentation/file.SASS_REFERENCE.html#Variable_Defaults___default).