### PR TITLE
feat(datepicker): Add-Init-Config for the first initialization

### DIFF
--- a/src/datepicker/bs-datepicker.component.ts
+++ b/src/datepicker/bs-datepicker.component.ts
@@ -120,6 +120,7 @@ export class BsDatepickerComponent implements OnInit, OnDestroy, OnChanges {
       triggers: this.triggers,
       show: () => this.show()
     });
+    this.setConfig();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -149,12 +150,7 @@ export class BsDatepickerComponent implements OnInit, OnDestroy, OnChanges {
       return;
     }
 
-    this._config = Object.assign({}, this._config, this.bsConfig, {
-      value: this._bsValue,
-      isDisabled: this.isDisabled,
-      minDate: this.minDate || this._config.minDate,
-      maxDate: this.maxDate || this._config.maxDate
-    });
+    this.setConfig();
 
     this._datepickerRef = this._datepicker
       .provide({provide: BsDatepickerConfig, useValue: this._config})
@@ -202,6 +198,18 @@ export class BsDatepickerComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     this.show();
+  }
+
+  /**
+   * Set config for datepicker
+   */
+  setConfig(): void {
+    this._config = Object.assign({}, this._config, this.bsConfig, {
+      value: this._bsValue,
+      isDisabled: this.isDisabled,
+      minDate: this.minDate || this._config.minDate,
+      maxDate: this.maxDate || this._config.maxDate
+    });
   }
 
   ngOnDestroy(): any {

--- a/src/datepicker/bs-daterangepicker.component.ts
+++ b/src/datepicker/bs-daterangepicker.component.ts
@@ -119,6 +119,7 @@ export class BsDaterangepickerComponent
       triggers: this.triggers,
       show: () => this.show()
     });
+    this.setConfig()
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -148,18 +149,7 @@ export class BsDaterangepickerComponent
       return;
     }
 
-    this._config = Object.assign(
-      {},
-      this._config,
-      {displayMonths: 2},
-      this.bsConfig,
-      {
-        value: this._bsValue,
-        isDisabled: this.isDisabled,
-        minDate: this.minDate || this._config.minDate,
-        maxDate: this.maxDate || this._config.maxDate
-      }
-    );
+    this.setConfig()
 
     this._datepickerRef = this._datepicker
       .provide({provide: BsDatepickerConfig, useValue: this._config})
@@ -183,6 +173,24 @@ export class BsDaterangepickerComponent
           this.bsValue = value;
           this.hide();
         })
+    );
+  }
+
+  /**
+   * Set config for daterangepicker
+   */
+  setConfig() {
+    this._config = Object.assign(
+      {},
+      this._config,
+      {displayMonths: 2},
+      this.bsConfig,
+      {
+        value: this._bsValue,
+        isDisabled: this.isDisabled,
+        minDate: this.minDate || this._config.minDate,
+        maxDate: this.maxDate || this._config.maxDate
+      }
     );
   }
 

--- a/src/datepicker/bs-daterangepicker.component.ts
+++ b/src/datepicker/bs-daterangepicker.component.ts
@@ -119,7 +119,7 @@ export class BsDaterangepickerComponent
       triggers: this.triggers,
       show: () => this.show()
     });
-    this.setConfig()
+    this.setConfig();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -149,7 +149,7 @@ export class BsDaterangepickerComponent
       return;
     }
 
-    this.setConfig()
+    this.setConfig();
 
     this._datepickerRef = this._datepicker
       .provide({provide: BsDatepickerConfig, useValue: this._config})


### PR DESCRIPTION
Add-Init-Config for DateRangePicker for the first initialization of the international date display.

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [ ] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [ ] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
