### PR TITLE
Fix/2929 display date on init

### DIFF
--- a/src/datepicker/bs-datepicker.component.ts
+++ b/src/datepicker/bs-datepicker.component.ts
@@ -69,6 +69,7 @@ export class BsDatepickerComponent implements OnInit, OnDestroy, OnChanges {
       return;
     }
     this._bsValue = value;
+    // wait for initialization bsValueChange subscribers
     setTimeout(() => {
       this.bsValueChange.emit(value);
     });

--- a/src/datepicker/bs-datepicker.component.ts
+++ b/src/datepicker/bs-datepicker.component.ts
@@ -69,7 +69,9 @@ export class BsDatepickerComponent implements OnInit, OnDestroy, OnChanges {
       return;
     }
     this._bsValue = value;
-    this.bsValueChange.emit(value);
+    setTimeout(() => {
+      this.bsValueChange.emit(value);
+    });
   }
 
   /**


### PR DESCRIPTION
- fix #2929 

I found out that Input interceptor for bsValue emit bsValueChange event before bs-datepicker-input.directive is initialised https://github.com/valor-software/ngx-bootstrap/blob/4e3e456251c64e0d279b731807667de66496a097/src/datepicker/bs-datepicker-input.directive.ts#L35

I used `setTimeout` to move execution at the end of stack. 
I'm new in angular 4 so maybe you can use better solution, but main problem is defined above

