### PR TITLE
feat(datepicker): Always using default config

### DIFF
--- a/src/datepicker/bs-datepicker-input.directive.ts
+++ b/src/datepicker/bs-datepicker-input.directive.ts
@@ -39,8 +39,8 @@ export class BsDatepickerInputDirective
   _setInputValue(v: Date): void {
     const initialDate = formatDate(
       v,
-      this._picker._config.dateInputFormat,
-      this._picker._config.locale
+      (this._picker.bsConfig || this._picker._config).dateInputFormat,
+      (this._picker.bsConfig || this._picker._config).locale
     ) || '';
     this._renderer.setProperty(this._elRef.nativeElement, 'value', initialDate);
     this._onChange(v);
@@ -56,10 +56,10 @@ export class BsDatepickerInputDirective
     if (!value) {
       this._picker.bsValue = null;
     }
-    const _locale = getLocale(this._picker._config.locale);
+    const _locale = getLocale((this._picker.bsConfig || this._picker._config).locale);
     if (!_locale) {
       throw new Error(
-        `Locale "${this._picker._config
+        `Locale "${(this._picker.bsConfig || this._picker._config)
           .locale}" is not defined, please add it with "defineLocale(...)"`
       );
     }


### PR DESCRIPTION
Always using default config "en"

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
