### PR TITLE
feat(timepicker): allow null value and change validation state on manual update

### DIFF
--- a/src/timepicker/timepicker.component.ts
+++ b/src/timepicker/timepicker.component.ts
@@ -27,6 +27,7 @@ import {
   parseTime,
   isInputValid
 } from './timepicker.utils';
+import { fakeAsync } from '@angular/core/testing';
 
 export const TIMEPICKER_CONTROL_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -205,6 +206,7 @@ export class TimepickerComponent
   _updateTime() {
     const _seconds = this.showSeconds ? this.seconds : void 0;
     if (!isInputValid(this.hours, this.minutes, _seconds, this.isPM())) {
+      this.isValid.emit(false);
       this.onChange(null);
 
       return;
@@ -239,6 +241,8 @@ export class TimepickerComponent
   writeValue(obj: any): void {
     if (isValidDate(obj)) {
       this._store.dispatch(this._timepickerActions.writeValue(parseTime(obj)));
+    } else if (obj == null) {
+      this._store.dispatch(this._timepickerActions.writeValue(null));
     }
   }
 


### PR DESCRIPTION
fixes #2907

go to:
http://localhost:4200/#/timepicker#dynamic

1. `clean button` should clean timepicker value
2. manually time `12:aa` (invalid time, should mark field as not valid)
this is kinda dirty

@EvilAlexei please add `timepicker` validation to v2 roadmap
