### PR TITLE
fix(old-datepicker): summer time

### DIFF
--- a/src/datepicker/datepicker-inner.component.ts
+++ b/src/datepicker/datepicker-inner.component.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:max-file-line-count */
+﻿/* tslint:disable:max-file-line-count */
 import {
   Component,
   EventEmitter,
@@ -219,6 +219,7 @@ export class DatePickerInnerComponent implements OnInit, OnChanges {
       date.getMonth(),
       date.getDate()
     );
+    dateObject.date = this.fixTimeZone(dateObject.date);
     dateObject.label = this.dateFilter(date, format);
     dateObject.selected = this.compare(date, this.selectedDate) === 0;
     dateObject.disabled = this.isDisabled(date);
@@ -265,6 +266,7 @@ export class DatePickerInnerComponent implements OnInit, OnChanges {
         date.getMonth(),
         date.getDate()
       );
+      this.activeDate = this.fixTimeZone(this.activeDate);
       if (isManual) {
         this.selectionDone.emit(this.activeDate);
       }
@@ -274,6 +276,7 @@ export class DatePickerInnerComponent implements OnInit, OnChanges {
         date.getMonth(),
         date.getDate()
       );
+      this.activeDate = this.fixTimeZone(this.activeDate);
       if (isManual) {
         this.datepickerMode = this.modes[
           this.modes.indexOf(this.datepickerMode) - 1

--- a/src/datepicker/daypicker.component.ts
+++ b/src/datepicker/daypicker.component.ts
@@ -1,4 +1,4 @@
-// @deprecated
+﻿// @deprecated
 // tslint:disable
 import { Component, OnInit } from '@angular/core';
 import { isBs3 } from '../utils/theme-provider';
@@ -179,9 +179,9 @@ export class DayPickerComponent implements OnInit {
       date = this.datePicker.fixTimeZone(date);
       dates[i++] = date;
       current = new Date(
-        current.getFullYear(),
-        current.getMonth(),
-        current.getDate() + 1
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate() + 1
       );
     }
     return dates;


### PR DESCRIPTION
Datepicker repeat days (ex:. 15-oct-2017) when using Safari (Mac) and lang pt-BR for summer time

Problem: Opening the datepicker on Safari in a month with summer time (ex:. 2017-oct-15 - lang: pt-BR) generates a calendar containing days 1,2,3,..,14, 15, 15, 15, 15,..., 15

Context: Safari "new Date(2017, 9, 15)" for lang pt-BR generates a date like "14 oct 2017 23:00:00", then the component "daypicker.component.ts" calls "fixTimeZone()" to fix that to "15 oct 2017" but that "fixed date" is not used to get the next day, which generates a loop of tha same day in theses cases of summer time.

Fix: Used the "fixed date" while generating/selecting days for the calendar