### PR TITLE
fix(datepicker): fix errors on fullTemplateTypeCheck rule

### DIFF
--- a/demo/src/tsconfig.json
+++ b/demo/src/tsconfig.json
@@ -18,5 +18,8 @@
     "typeRoots": [
       "../node_modules/@types"
     ]
+  },
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/datepicker/datepicker-inner.component.ts
+++ b/src/datepicker/datepicker-inner.component.ts
@@ -64,23 +64,18 @@ export class DatePickerInnerComponent implements OnInit, OnChanges {
   @Input() dateDisabled: { date: Date; mode: string }[];
   @Input() initDate: Date;
 
-  @Output()
-  selectionDone: EventEmitter<Date> = new EventEmitter<Date>(undefined);
-
+  @Output() selectionDone: EventEmitter<Date> = new EventEmitter<Date>(undefined);
   @Output() update: EventEmitter<Date> = new EventEmitter<Date>(false);
-
-  @Output()
-  activeDateChange: EventEmitter<Date> = new EventEmitter<Date>(
-    undefined
-  );
+  @Output() activeDateChange: EventEmitter<Date> = new EventEmitter<Date>(undefined);
 
   stepDay: any = {};
   stepMonth: any = {};
   stepYear: any = {};
 
+  uniqueId: string;
+
   protected modes: string[] = ['day', 'month', 'year'];
   protected dateFormatter: DateFormatter = new DateFormatter();
-  protected uniqueId: string;
   protected _activeDate: Date;
   protected selectedDate: Date;
   protected activeDateId: string;

--- a/src/datepicker/daypicker.component.ts
+++ b/src/datepicker/daypicker.component.ts
@@ -7,7 +7,7 @@ import { DatePickerInnerComponent } from './datepicker-inner.component';
 @Component({
   selector: 'daypicker',
   template: `
-<table *ngIf="datePicker.datepickerMode==='day'" role="grid" [attr.aria-labelledby]="datePicker.uniqueId+'-title'" aria-activedescendant="activeDateId">
+<table *ngIf="datePicker.datepickerMode === 'day'" role="grid" [attr.aria-labelledby]="datePicker.uniqueId + '-title'" aria-activedescendant="activeDateId">
   <thead>
     <tr>
       <th>
@@ -25,7 +25,7 @@ import { DatePickerInnerComponent } from './datepicker-inner.component';
       <th [attr.colspan]="5 + (datePicker.showWeeks ? 1 : 0)">
         <button [id]="datePicker.uniqueId + '-title'"
                 type="button" class="btn btn-default btn-secondary btn-sm"
-                (click)="datePicker.toggleMode()"
+                (click)="datePicker.toggleMode(0)"
                 [disabled]="datePicker.datepickerMode === datePicker.maxMode"
                 [ngClass]="{disabled: datePicker.datepickerMode === datePicker.maxMode}" tabindex="-1" style="width:100%;">
           <strong>{{ title }}</strong>

--- a/src/datepicker/monthpicker.component.ts
+++ b/src/datepicker/monthpicker.component.ts
@@ -17,7 +17,7 @@ import { DatePickerInnerComponent } from './datepicker-inner.component';
       <th [attr.colspan]="((datePicker.monthColLimit - 2) <= 0) ? 1 : datePicker.monthColLimit - 2">
         <button [id]="datePicker.uniqueId + '-title'"
                 type="button" class="btn btn-default btn-sm"
-                (click)="datePicker.toggleMode()"
+                (click)="datePicker.toggleMode(0)"
                 [disabled]="datePicker.datepickerMode === maxMode"
                 [ngClass]="{disabled: datePicker.datepickerMode === maxMode}" tabindex="-1" style="width:100%;">
           <strong>{{ title }}</strong> 

--- a/src/datepicker/themes/bs/bs-datepicker-view.html
+++ b/src/datepicker/themes/bs/bs-datepicker-view.html
@@ -8,7 +8,7 @@
       <div *ngSwitchCase="'day'">
         <bs-days-calendar-view
           *ngFor="let calendar of (daysCalendar | async)"
-          [class.bs-datepicker-multiple]="(daysCalendar | async).length > 1"
+          [class.bs-datepicker-multiple]="(daysCalendar | async)?.length > 1"
           [calendar]="calendar"
           [options]="options | async"
           (onNavigate)="navigateTo($event)"
@@ -21,8 +21,8 @@
       <!--months calendar-->
       <div *ngSwitchCase="'month'">
         <bs-month-calendar-view
-          *ngFor="let calendar of (monthsCalendar   | async)"
-          [class.bs-datepicker-multiple]="(daysCalendar   | async).length > 1"
+          *ngFor="let calendar of (monthsCalendar | async)"
+          [class.bs-datepicker-multiple]="(daysCalendar | async)?.length > 1"
           [calendar]="calendar"
           (onNavigate)="navigateTo($event)"
           (onViewMode)="setViewMode($event)"
@@ -34,8 +34,8 @@
       <!--years calendar-->
       <div *ngSwitchCase="'year'">
         <bs-years-calendar-view
-          *ngFor="let calendar of (yearsCalendar   | async)"
-          [class.bs-datepicker-multiple]="(daysCalendar | async).length > 1"
+          *ngFor="let calendar of (yearsCalendar | async)"
+          [class.bs-datepicker-multiple]="(daysCalendar | async)?.length > 1"
           [calendar]="calendar"
           (onNavigate)="navigateTo($event)"
           (onViewMode)="setViewMode($event)"

--- a/src/datepicker/yearpicker.component.ts
+++ b/src/datepicker/yearpicker.component.ts
@@ -18,7 +18,7 @@ import { DatePickerInnerComponent } from './datepicker-inner.component';
       <th [attr.colspan]="((datePicker.yearColLimit - 2) <= 0) ? 1 : datePicker.yearColLimit - 2">
         <button [id]="datePicker.uniqueId + '-title'" role="heading"
                 type="button" class="btn btn-default btn-sm"
-                (click)="datePicker.toggleMode()"
+                (click)="datePicker.toggleMode(0)"
                 [disabled]="datePicker.datepickerMode === datePicker.maxMode"
                 [ngClass]="{disabled: datePicker.datepickerMode === datePicker.maxMode}" tabindex="-1" style="width:100%;">
           <strong>{{ title }}</strong>

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -33,6 +33,7 @@
   "angularCompilerOptions": {
     "genDir": "../temp/factories",
     "strictMetadataEmit": true,
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "../dist",
+    "rootDir": "./",
     "target": "es5",
     "module": "es2015",
     "moduleResolution": "node",


### PR DESCRIPTION
fixes #3455
* `protected uniqueId: string;` is not accessable in components that use `DatePickerInnerComponent` via Injector
* `datePicker.toggleMode()` requires one parameter