### PR TITLE
Fix bootstrap link

### DIFF
--- a/demo/src/app/common/app-footer/app-footer.component.html
+++ b/demo/src/app/common/app-footer/app-footer.component.html
@@ -2,5 +2,5 @@
   <p>Designed and built by the <a href="https://github.com/orgs/valor-software/teams/ng-team" target="_blank" rel="noopener">ng-team</a>
     with the help of our <a href="https://github.com/valor-software/ngx-bootstrap/graphs/contributors" target="_blank" rel="noopener">contributors.</a></p>
   <p>Code licensed under <a href="https://github.com/valor-software/ngx-bootstrap/blob/development/LICENSE" target="_blank" rel="noopener">MIT license conditions</a>, docs <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank" rel="noopener">CC BY 3.0</a></p>
-  <p>Design and content of the documentation site heavily inspired by the <a  target="_blank" rel="noopener" href="http://v4-alpha.getbootstrap.com/">original bootstrap</a> documentation</p>
+  <p>Design and content of the documentation site heavily inspired by the <a target="_blank" rel="noopener" href="https://getbootstrap.com/">original bootstrap.</a> documentation</p>
 </footer>


### PR DESCRIPTION
Change link from pointing to the alpha bootstrap version to the latest website version. Replaces #3512 since this PR is on the `development` branch.