### PR TITLE
chore(docs): link to org site instead of ng-team (404 response)

### DIFF
--- a/demo/src/app/common/app-footer/app-footer.component.html
+++ b/demo/src/app/common/app-footer/app-footer.component.html
@@ -1,5 +1,5 @@
 <footer class="app-footer">
-  <p>Designed and built by the <a href="https://github.com/orgs/valor-software/teams/ng-team" target="_blank" rel="noopener">ng-team</a>
+  <p>Designed and built by the ng-team at <a href="https://github.com/valor-software" target="_blank" rel="noopener">Valor Software</a>
     with the help of our <a href="https://github.com/valor-software/ngx-bootstrap/graphs/contributors" target="_blank" rel="noopener">contributors.</a></p>
   <p>Code licensed under <a href="https://github.com/valor-software/ngx-bootstrap/blob/development/LICENSE" target="_blank" rel="noopener">MIT license conditions</a>, docs <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank" rel="noopener">CC BY 3.0</a></p>
   <p>Design and content of the documentation site heavily inspired by the <a target="_blank" rel="noopener" href="https://getbootstrap.com/">original bootstrap.</a> documentation</p>


### PR DESCRIPTION
I assume that the `ng-team` at valor software can be accessed privately only. Proposed is a chagne to link to the publicly accessible valor software org page at github instead.