### PR TITLE
Fix sidebar-content display bug in the demo page

### DIFF
--- a/demo/src/assets/css/style.scss
+++ b/demo/src/assets/css/style.scss
@@ -539,7 +539,7 @@ a:hover {
 }
 /* below 1504 */
 @media (max-width: 1504px) {
-  .sidebar-content{
+  .sidebar-content {
     max-height: calc(100vh - 246px); // header + search field + bootstrap buttons field
   }
 }

--- a/demo/src/assets/css/style.scss
+++ b/demo/src/assets/css/style.scss
@@ -262,7 +262,7 @@ a:hover {
   &-content {
     padding: 15px 19px 15px 20px;
     overflow: auto;
-    max-height: calc(100vh - 194px); // header + search field + bootstrap buttons field
+    max-height: calc(100vh - 207px); // header + search field + bootstrap buttons field
   }
 
   &-list {
@@ -535,6 +535,12 @@ a:hover {
   }
   #mobile-main-menu {
     display: none;
+  }
+}
+/* below 1504 */
+@media (max-width: 1504px) {
+  .sidebar-content{
+    max-height: calc(100vh - 246px); // header + search field + bootstrap buttons field
   }
 }
 /* below 1200 */


### PR DESCRIPTION
It's about some display bug in https://valor-software.com/ngx-bootstrap/#/getting-started
When the browser width under 1504px the sidebar-content max-height not changed correspondingly, so we can not see the Typehead menu. And the sidebar-content is a little taller when browser width above 1504px.