### PR TITLE
docs(timepicker): add meridians property demo

### DIFF
--- a/demo/src/app/components/+timepicker/demos/custom-meridian/custom-meridian.html
+++ b/demo/src/app/components/+timepicker/demos/custom-meridian/custom-meridian.html
@@ -1,0 +1,3 @@
+<timepicker [(ngModel)]="mytime" [meridians]="meridians"></timepicker>
+
+<pre class="alert alert-info">Time is: {{mytime}}</pre>

--- a/demo/src/app/components/+timepicker/demos/custom-meridian/custom-meridian.ts
+++ b/demo/src/app/components/+timepicker/demos/custom-meridian/custom-meridian.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'demo-timepicker-custom-meridian',
+  templateUrl: './custom-meridian.html'
+})
+export class DemoTimepickerCustomMeridianComponent {
+  mytime: Date = new Date();
+  meridians = ['12H', '24H'];
+}

--- a/demo/src/app/components/+timepicker/demos/index.ts
+++ b/demo/src/app/components/+timepicker/demos/index.ts
@@ -1,6 +1,7 @@
 import { DemoTimepickerBasicComponent } from './basic/basic';
 import { DemoTimepickerConfigComponent } from './config/config';
 import { DemoTimepickerMeridianComponent } from './meridian/meridian';
+import { DemoTimepickerCustomMeridianComponent } from './custom-meridian/custom-meridian';
 import { DemoTimepickerDisabledComponent } from './disabled/disabled';
 import { DemoTimepickerCustomComponent } from './custom/custom';
 import { DemoTimepickerDynamicComponent } from './dynamic/dynamic';
@@ -13,6 +14,7 @@ export const DEMO_COMPONENTS = [
   DemoTimepickerBasicComponent,
   DemoTimepickerConfigComponent,
   DemoTimepickerMeridianComponent,
+  DemoTimepickerCustomMeridianComponent,
   DemoTimepickerMinMaxComponent,
   DemoTimepickerDisabledComponent,
   DemoTimepickerCustomComponent,

--- a/demo/src/app/components/+timepicker/timepicker-section.list.ts
+++ b/demo/src/app/components/+timepicker/timepicker-section.list.ts
@@ -1,5 +1,6 @@
 import { DemoTimepickerBasicComponent } from './demos/basic/basic';
 import { DemoTimepickerMeridianComponent } from './demos/meridian/meridian';
+import { DemoTimepickerCustomMeridianComponent } from './demos/custom-meridian/custom-meridian';
 import { DemoTimepickerMinMaxComponent } from './demos/min-max/min-max';
 import { DemoTimepickerToggleMinutesSecondsComponent } from './demos/toggle-minutes-seconds/toggle-minutes-seconds';
 import { DemoTimepickerDisabledComponent } from './demos/disabled/disabled';
@@ -46,6 +47,13 @@ export const demoComponentContent: ContentSection[] = [
         component: require('!!raw-loader?lang=typescript!./demos/meridian/meridian'),
         html: require('!!raw-loader?lang=markup!./demos/meridian/meridian.html'),
         outlet: DemoTimepickerMeridianComponent
+      },
+      {
+        title: 'Custom meridian',
+        anchor: 'custom-meridian',
+        component: require('!!raw-loader?lang=typescript!./demos/custom-meridian/custom-meridian'),
+        html: require('!!raw-loader?lang=markup!./demos/custom-meridian/custom-meridian.html'),
+        outlet: DemoTimepickerCustomMeridianComponent
       },
       {
         title: 'Min - Max',


### PR DESCRIPTION
add demo with meridians property
`meridians` property of timepicker is used to change default labels of `12H/24H` button. works like `am/pm` button.
closes #3726

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated demos.
