### PR TITLE
docs(popover): clarify Dynamic Content demo

### DIFF
--- a/demo/src/app/components/+popover/demos/custom-content/custom-content.html
+++ b/demo/src/app/components/+popover/demos/custom-content/custom-content.html
@@ -1,0 +1,5 @@
+<ng-template #popTemplate>Just another: {{content}}</ng-template>
+<button type="button" class="btn btn-warning"
+        [popover]="popTemplate" popoverTitle="Template ref content inside">
+  TemplateRef binding
+</button>

--- a/demo/src/app/components/+popover/demos/custom-content/custom-content.ts
+++ b/demo/src/app/components/+popover/demos/custom-content/custom-content.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'demo-popover-dynamic',
-  templateUrl: './dynamic.html'
+  selector: 'demo-popover-custom-content',
+  templateUrl: './custom-content.html'
 })
-export class DemoPopoverDynamicComponent {
+export class DemoPopoverCustomContentComponent {
   title = 'Welcome word';
   content = 'Vivamus sagittis lacus vel augue laoreet rutrum faucibus.';
 }

--- a/demo/src/app/components/+popover/demos/dynamic/dynamic.html
+++ b/demo/src/app/components/+popover/demos/dynamic/dynamic.html
@@ -2,9 +2,3 @@
         [popover]="content" [popoverTitle]="title">
   Simple binding
 </button>
-
-<ng-template #popTemplate>Just another: {{content}}</ng-template>
-<button type="button" class="btn btn-warning"
-        [popover]="popTemplate" popoverTitle="Template ref content inside">
-  TemplateRef binding
-</button>

--- a/demo/src/app/components/+popover/demos/index.ts
+++ b/demo/src/app/components/+popover/demos/index.ts
@@ -2,6 +2,7 @@ import { DemoPopoverBasicComponent } from './basic/basic';
 import { DemoPopoverPlacementComponent } from './placement/placement';
 import { DemoPopoverDismissComponent } from './dismiss/dismiss';
 import { DemoPopoverDynamicComponent } from './dynamic/dynamic';
+import { DemoPopoverCustomContentComponent } from './custom-content/custom-content';
 import { DemoPopoverDynamicHtmlComponent } from './dynamic-html/dynamic-html';
 import { DemoPopoverContainerComponent } from './container/container';
 import { DemoPopoverConfigComponent } from './config/config';
@@ -20,6 +21,7 @@ export const DEMO_COMPONENTS = [
   DemoPopoverPlacementComponent,
   DemoPopoverDismissComponent,
   DemoPopoverDynamicComponent,
+  DemoPopoverCustomContentComponent,
   DemoPopoverDynamicHtmlComponent,
   DemoPopoverContainerComponent,
   DemoPopoverConfigComponent,

--- a/demo/src/app/components/+popover/popover-section.list.ts
+++ b/demo/src/app/components/+popover/popover-section.list.ts
@@ -2,6 +2,7 @@ import { DemoPopoverBasicComponent } from './demos/basic/basic';
 import { DemoPopoverPlacementComponent } from './demos/placement/placement';
 import { DemoPopoverDismissComponent } from './demos/dismiss/dismiss';
 import { DemoPopoverDynamicComponent } from './demos/dynamic/dynamic';
+import { DemoPopoverCustomContentComponent } from './demos/custom-content/custom-content';
 import { DemoPopoverDynamicHtmlComponent } from './demos/dynamic-html/dynamic-html';
 import { DemoPopoverContainerComponent } from './demos/container/container';
 import { DemoPopoverConfigComponent } from './demos/config/config';
@@ -65,14 +66,21 @@ export const demoComponentContent: ContentSection[] = [
         outlet: DemoPopoverDismissComponent
       },
       {
-        title: 'Dynamic Content',
+        title: 'Dynamic content',
         anchor: 'dynamic-content',
         component: require('!!raw-loader?lang=typescript!./demos/dynamic/dynamic.ts'),
         html: require('!!raw-loader?lang=markup!./demos/dynamic/dynamic.html'),
-        description: `<p>Popover content can contain any html template. Just create <code>&lt;template
-        #myId></code> with any html allowed by Angular, and provide template ref (<code>#myId</code>)
-        as popover content.</p>`,
+        description: `<p>Pass a string as popover content.</p>`,
         outlet: DemoPopoverDynamicComponent
+      },
+      {
+        title: 'Custom content template',
+        anchor: 'custom-content-template',
+        component: require('!!raw-loader?lang=typescript!./demos/custom-content/custom-content.ts'),
+        html: require('!!raw-loader?lang=markup!./demos/custom-content/custom-content.html'),
+        description: `<p>Create <code>&lt;template #myId></code> with any html allowed by Angular,
+        and provide template ref (<code>#myId</code>) as popover content.</p>`,
+        outlet: DemoPopoverCustomContentComponent
       },
       {
         title: 'Dynamic Html',


### PR DESCRIPTION
Separate options in description. The current demo has a description only for TemplateRef binding. I've split this demo into two demos and added description for Simple binding.

Closes #3834

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated demos.
