### PR TITLE
fix(demo): add null check in preventEmptyHrefNav method

### DIFF
--- a/demo/src/app/docs/demo-section-components/demo-examples-section/examples.component.ts
+++ b/demo/src/app/docs/demo-section-components/demo-examples-section/examples.component.ts
@@ -26,7 +26,7 @@ export class ExamplesComponent {
     }
 
     if (element.tagName !== 'A') {
-      while (element !== document.body)  {
+      while (element.parentElement && element !== document.body)  {
         if (preventNav) {
           event.preventDefault();
           return;


### PR DESCRIPTION

This PR fixes error that is thrown on click on several elements on demo page (due to not very strict check in method that is used to prevent redirect from links with `href="#"`)
![01fcf3ebaf](https://user-images.githubusercontent.com/18414330/37104249-e7da06e2-2234-11e8-95b8-65a5d4edfe48.jpg)

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.

