### PR TITLE
fix(test): update @types/webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@types/jasmine": "2.8.4",
     "@types/marked": "0.3.0",
     "@types/node": "8.5.1",
-    "@types/webpack": "3.8.3",
+    "@types/webpack": "4.1.0",
     "awesome-typescript-loader": "3.4.1",
     "bootstrap": "4.0.0",
     "chai": "4.1.2",


### PR DESCRIPTION
Fixes this error during `ng test`
```
Error: 
C:/Source/ngx-bootstrap/node_modules/@types/webpack/index.d.ts (530,28): Type 'typeof "C:/Source/ngx-bootstrap/node_modules/@types/tapable/index"' is not a constructor function type.,
C:/Source/ngx-bootstrap/node_modules/@types/webpack/index.d.ts (557,42): Type 'typeof "C:/Source/ngx-bootstrap/node_modules/@types/tapable/index"' is not a constructor function type.,
C:/Source/ngx-bootstrap/node_modules/@types/webpack/index.d.ts (573,46): Namespace '"C:/Source/ngx-bootstrap/node_modules/@types/tapable/index"' has no exported member 'Plugin'.,
C:/Source/ngx-bootstrap/node_modules/@types/webpack/index.d.ts (577,53): Namespace '"C:/Source/ngx-bootstrap/node_modules/@types/tapable/index"' has no exported member 'Plugin'.
```

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
