### PR TITLE
docs(alert): mark dismissible property name as code for basic alert demo

### DIFF
--- a/demo/src/app/components/+alerts/alerts-section.list.ts
+++ b/demo/src/app/components/+alerts/alerts-section.list.ts
@@ -39,8 +39,7 @@ export const demoComponentContent: ContentSection[] = [
         description: `<p>Alerts are available for any length of text, as well as an optional dismiss
           button. For proper styling, use one of the four <strong>required</strong>
           contextual classes (e.g., <code>.alert-success</code>). For inline
-          dismissal, use the <a routerLink="." fragment="dismissing"><code>dismiss
-          property</code></a>.</p>`,
+          dismissal, use the <code>dismissible</code> property.</p>`,
         component: require('!!raw-loader?lang=typescript!./demos/basic/basic'),
         html: require('!!raw-loader?lang=markup!./demos/basic/basic.html'),
         outlet: DemoAlertBasicComponent

--- a/demo/src/ng-api-doc.ts
+++ b/demo/src/ng-api-doc.ts
@@ -796,6 +796,12 @@ export const ngdoc: any = {
         "description": "<p>Default min date for all date/range pickers</p>\n"
       },
       {
+        "name": "rangeInputFormat",
+        "defaultValue": "L",
+        "type": "string",
+        "description": "<p>Date format for date range input field</p>\n"
+      },
+      {
         "name": "showWeekNumbers",
         "defaultValue": "true",
         "type": "boolean",


### PR DESCRIPTION
# PR Checklist
 - [x] built and tested the changes locally.
 - [x] added/updated demos.

Edit description for Basic example at Alert demo page.
Mark `dismissible` property as code by deleting unused routing

How it was displayed before:
![dismisspropalert](https://user-images.githubusercontent.com/27342505/37359106-645004e6-26f5-11e8-9c6b-2fc65b3e9431.jpg)
How it looks now:
![dismissalert](https://user-images.githubusercontent.com/27342505/37359116-6cfdf2d8-26f5-11e8-9be2-0b902710e772.jpg)
