### PR TITLE
docs(datepicker): mark properties names as code for initial state datepicker demo

### DIFF
--- a/demo/src/app/components/+datepicker/demos/date-initial-state/date-initial-state.html
+++ b/demo/src/app/components/+datepicker/demos/date-initial-state/date-initial-state.html
@@ -1,4 +1,4 @@
-<p>bsValue property sets initial state in this example</p>
+<p><code>bsValue</code> property sets initial state in this example</p>
 <div class="row">
   <div class="col-xs-12 col-12 col-md-4 form-group">
     <input type="text"
@@ -12,7 +12,7 @@
   </div>
 </div>
 
-<p>ngModel property sets two-way data binding in this example</p>
+<p><code>ngModel</code> property sets two-way data binding in this example</p>
 <div class="row">
   <div class="col-xs-12 col-12 col-md-4 form-group">
     <input class="form-control" #drp="bsDaterangepicker" bsDaterangepicker [(ngModel)]="bsRangeValue">

--- a/demo/src/ng-api-doc.ts
+++ b/demo/src/ng-api-doc.ts
@@ -796,6 +796,12 @@ export const ngdoc: any = {
         "description": "<p>Default min date for all date/range pickers</p>\n"
       },
       {
+        "name": "rangeInputFormat",
+        "defaultValue": "L",
+        "type": "string",
+        "description": "<p>Date format for date range input field</p>\n"
+      },
+      {
         "name": "showWeekNumbers",
         "defaultValue": "true",
         "type": "boolean",


### PR DESCRIPTION
# PR Checklist
 - [x] built and tested the changes locally.
 - [x] added/updated demos.

Link to github issue with full description and with steps to reproduce: https://github.com/valor-software/ngx-bootstrap/issues/3980
How properties' names looks after fix:
![initstatepropmarked](https://user-images.githubusercontent.com/27342505/37361376-696c5032-26fb-11e8-9b47-6b60a18ab453.jpg)
