### PR TITLE
docs(datepicker): fix description at placement datepicker demo by changing text's tag

### DIFF
--- a/demo/src/app/components/+datepicker/demos/placement/placement.html
+++ b/demo/src/app/components/+datepicker/demos/placement/placement.html
@@ -1,27 +1,27 @@
 <div class="row">
   <div class="col-xs-12 col-12 col-sm-6 col-md-3 form-group">
-    <label>The datepicker's placement is right</label>
+    <p>The datepicker's placement is right</p>
     <input class="form-control"
       placeholder="Datepicker"
       bsDatepicker
       placement="right">
   </div>
   <div class="col-xs-12 col-12 col-sm-6 col-md-3 form-group">
-    <label>The datepicker's placement is top</label>
+    <p>The datepicker's placement is top</p>
     <input class="form-control"
       placeholder="Datepicker"
       bsDatepicker
       placement="top">
   </div>
   <div class="col-xs-12 col-12 col-sm-6 col-md-3 form-group">
-    <label>The datepicker's placement is bottom</label>
+    <p>The datepicker's placement is bottom</p>
     <input class="form-control"
       placeholder="Datepicker"
       bsDatepicker
       placement="bottom">
     </div>
   <div class="col-xs-12 col-12 col-sm-6 col-md-3 form-group">
-    <label>The datepicker's placement is left</label>
+    <p>The datepicker's placement is left</p>
     <input class="form-control"
       placeholder="Datepicker"
       bsDatepicker


### PR DESCRIPTION
# PR Checklist
 - [x] built and tested the changes locally.
 - [x] updated demos.

closes: https://github.com/valor-software/ngx-bootstrap/issues/4004
Change tag for outputs' descriptions for avoiding text style dependence on bootstrap version (it becames bold for bs3, and now not)
With tag `label` (before this PR): 
![placementtextbs3](https://user-images.githubusercontent.com/27342505/37473414-f430d950-2876-11e8-8c78-22ca3a8ef7ea.jpg)

With tag `p` (in this PR):
![fixedtextplacement](https://user-images.githubusercontent.com/27342505/37473683-520bddcc-2877-11e8-9fe6-97f4fb838b5f.jpg)