### PR TITLE
docs(datepicker): fix description at outside click datepicker demo by changing tag

### DIFF
--- a/demo/src/app/components/+datepicker/demos/outside-click/outside-click.html
+++ b/demo/src/app/components/+datepicker/demos/outside-click/outside-click.html
@@ -1,10 +1,10 @@
 <div class="row">
   <div class="col-xs-12 col-12 col-sm-6 col-md-5 form-group">
-    <label>Outside click closes the datepicker in this example</label>
+    <p>Outside click closes the datepicker in this example</p>
     <input class="form-control" placeholder="Datepicker" bsDatepicker [outsideClick]="true">
   </div>
   <div class="col-xs-12 col-12 col-sm-6 col-md-5 form-group">
-    <label>Outside click doesn't close the datepicker in this example</label>
+    <p>Outside click doesn't close the datepicker in this example</p>
     <input class="form-control" placeholder="Datepicker" bsDatepicker [outsideClick]="false">
   </div>
 </div>


### PR DESCRIPTION
# PR Checklist
 - [x] built and tested the changes locally.
 - [x] updated demos.

closes: https://github.com/valor-software/ngx-bootstrap/issues/4007
Change tag for outputs' descriptions for avoiding text style dependence on bootstrap version (with tag `label` text was displayed bold for bs3, and using tag `p` instead of it solved issue)
With tag `label` for bs3: 
![outsideclickbs3](https://user-images.githubusercontent.com/27342505/37480051-e6076a78-2886-11e8-8c46-9a916062edd3.jpg)
With tag `p` for bs3:
![outsideclickbs3tagp](https://user-images.githubusercontent.com/27342505/37480145-27e12c68-2887-11e8-86f3-cafd7c75f4b2.jpg)