### PR TITLE
Added prefix for typeahead directive

### DIFF
--- a/demo/src/app/components/+typeahead/demos/async/async.html
+++ b/demo/src/app/components/+typeahead/demos/async/async.html
@@ -1,7 +1,7 @@
 <pre class="card card-block card-header">Model: {{asyncSelected | json}}</pre>
 
 <input [(ngModel)]="asyncSelected"
-       [typeahead]="dataSource"
+       [bsTypeahead]="dataSource"
        (typeaheadLoading)="changeTypeaheadLoading($event)"
        (typeaheadOnSelect)="typeaheadOnSelect($event)"
        [typeaheadOptionsLimit]="7"

--- a/demo/src/app/components/+typeahead/demos/basic/basic.html
+++ b/demo/src/app/components/+typeahead/demos/basic/basic.html
@@ -1,4 +1,4 @@
 <pre class="card card-block card-header mb-3">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"
-       [typeahead]="states"
+       [bsTypeahead]="states"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/container/container.html
+++ b/demo/src/app/components/+typeahead/demos/container/container.html
@@ -1,6 +1,6 @@
 <pre class="card card-block card-header mb-3">Model: {{selected | json}}</pre>
 
 <input [(ngModel)]="selected"
-       [typeahead]="states"
+       [bsTypeahead]="states"
        container="body"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/delay/delay.html
+++ b/demo/src/app/components/+typeahead/demos/delay/delay.html
@@ -1,5 +1,5 @@
 <pre class="card card-block card-header">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"
-       [typeahead]="states"
+       [bsTypeahead]="states"
        typeaheadWaitMs="1000"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/dropup/dropup.html
+++ b/demo/src/app/components/+typeahead/demos/dropup/dropup.html
@@ -1,5 +1,5 @@
 <pre class="card card-block card-header mb-3">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"
-       [typeahead]="states"
+       [bsTypeahead]="states"
        [dropup]="true"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/field/field.html
+++ b/demo/src/app/components/+typeahead/demos/field/field.html
@@ -1,5 +1,5 @@
 <pre class="card card-block card-header mb-3">Model: {{customSelected | json}}</pre>
 <input [(ngModel)]="customSelected"
-       [typeahead]="statesComplex"
+       [bsTypeahead]="statesComplex"
        typeaheadOptionField="name"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/form/form.html
+++ b/demo/src/app/components/+typeahead/demos/form/form.html
@@ -9,6 +9,6 @@
   <div class="form-group">
     <label for="state">State</label>
     <input id="state" class="form-control" name="state"
-           [(ngModel)]="model.state" [typeahead]="states">
+           [(ngModel)]="model.state" [bsTypeahead]="states">
   </div>
 </form>

--- a/demo/src/app/components/+typeahead/demos/grouping/grouping.html
+++ b/demo/src/app/components/+typeahead/demos/grouping/grouping.html
@@ -1,6 +1,6 @@
 <pre class="card card-block card-header mb-3">Model: {{groupSelected | json}}</pre>
 <input [(ngModel)]="groupSelected"
-       [typeahead]="statesComplex"
+       [bsTypeahead]="statesComplex"
        typeaheadOptionField="name"
        typeaheadGroupField="region"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/item-template/item-template.html
+++ b/demo/src/app/components/+typeahead/demos/item-template/item-template.html
@@ -4,6 +4,6 @@
 
 <pre class="card card-block card-header mb-3">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"
-       [typeahead]="states"
+       [bsTypeahead]="states"
        [typeaheadItemTemplate]="customItemTemplate"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/latinize/latinize.html
+++ b/demo/src/app/components/+typeahead/demos/latinize/latinize.html
@@ -1,5 +1,5 @@
 <pre class="card card-block card-header">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"
-       [typeahead]="frenchWords"
+       [bsTypeahead]="frenchWords"
        [typeaheadLatinize]="true"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/no-result/no-result.html
+++ b/demo/src/app/components/+typeahead/demos/no-result/no-result.html
@@ -2,6 +2,6 @@
 <div class="alert alert-danger" *ngIf="noResult">No Results Found</div>
 
 <input [(ngModel)]="selected"
-       [typeahead]="states"
+       [bsTypeahead]="states"
        (typeaheadNoResults)="typeaheadNoResults($event)"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/on-blur/on-blur.html
+++ b/demo/src/app/components/+typeahead/demos/on-blur/on-blur.html
@@ -2,6 +2,6 @@
 <pre class="card card-block card-header">Option on blur: {{optionOnBlur | json}}</pre>
 
 <input [(ngModel)]="selected"
-       [typeahead]="states"
+       [bsTypeahead]="states"
        (typeaheadOnBlur)="typeaheadOnBlur($event)"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/on-select/on-select.html
+++ b/demo/src/app/components/+typeahead/demos/on-select/on-select.html
@@ -2,7 +2,7 @@
 <pre class="card card-block card-header mb-3">Selected option: {{selectedOption | json}}</pre>
 
 <input [(ngModel)]="selectedValue"
-       [typeahead]="states"
+       [bsTypeahead]="states"
        typeaheadOptionField="name"
        (typeaheadOnSelect)="onSelect($event)"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/phrase-delimiters/phrase-delimiters.html
+++ b/demo/src/app/components/+typeahead/demos/phrase-delimiters/phrase-delimiters.html
@@ -1,6 +1,6 @@
 <pre class="card card-block card-header">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"
-       [typeahead]="states"
+       [bsTypeahead]="states"
        [typeaheadSingleWords]="true"
        typeaheadPhraseDelimiters="&,"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/reactive-form/reactive-form.html
+++ b/demo/src/app/components/+typeahead/demos/reactive-form/reactive-form.html
@@ -2,7 +2,7 @@
 
 <form [formGroup]="myForm">
   <input formControlName="state"
-         [typeahead]="states"
+         [bsTypeahead]="states"
          [typeaheadOptionsLimit]="7"
          [typeaheadMinLength]="0"
          placeholder="Typeahead inside a form"

--- a/demo/src/app/components/+typeahead/demos/scrollable/scrollable.html
+++ b/demo/src/app/components/+typeahead/demos/scrollable/scrollable.html
@@ -1,6 +1,6 @@
 <pre class="card card-block card-header mb-3">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"
-       [typeahead]="states"
+       [bsTypeahead]="states"
        [typeaheadScrollable]="true"
        [typeaheadOptionsInScrollableView]="5"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/single-world/single-world.html
+++ b/demo/src/app/components/+typeahead/demos/single-world/single-world.html
@@ -6,6 +6,6 @@
   Model: {{selected | json}}
 </pre>
 <input [(ngModel)]="selected"
-       [typeahead]="states"
+       [bsTypeahead]="states"
        [typeaheadSingleWords]="typeaheadSingleWords"
        class="form-control">

--- a/demo/src/ng-api-doc.ts
+++ b/demo/src/ng-api-doc.ts
@@ -3139,7 +3139,7 @@ export const ngdoc: any = {
     "fileName": "src/typeahead/typeahead.directive.ts",
     "className": "TypeaheadDirective",
     "description": "",
-    "selector": "[typeahead]",
+    "selector": "[bsTypeahead], [typeahead]",
     "exportAs": "bs-typeahead",
     "inputs": [
       {
@@ -3159,7 +3159,7 @@ export const ngdoc: any = {
         "description": "<p>used to specify a custom options list template.\nTemplate variables: matches, itemTemplate, query</p>\n"
       },
       {
-        "name": "typeahead",
+        "name": "bsTypeahead",
         "type": "any",
         "description": "<p>options source, can be Array of strings, objects or\nan Observable for external matching process</p>\n"
       },
@@ -3233,6 +3233,11 @@ export const ngdoc: any = {
         "defaultValue": " ",
         "type": "string",
         "description": "<p>should be used only in case typeaheadSingleWords attribute is true.\nSets the word delimiter to break words. Defaults to space.</p>\n"
+      },
+      {
+        "name": "typeahead",
+        "type": "any",
+        "description": ""
       }
     ],
     "outputs": [

--- a/src/spec/typeahead.directive.spec.ts
+++ b/src/spec/typeahead.directive.spec.ts
@@ -84,7 +84,7 @@ describe('Directive: Typeahead', () => {
     });
 
     it('should typeaheadAsync to false, if typeahead is an observable', () => {
-      directive.typeahead = Observable.of(component.states);
+      directive.bsTypeahead = Observable.of(component.states);
       directive.ngOnInit();
 
       expect(directive.typeaheadAsync).toBeTruthy();

--- a/src/spec/typeahead.directive.spec.ts
+++ b/src/spec/typeahead.directive.spec.ts
@@ -19,7 +19,7 @@ interface State {
   // (typeaheadOnSelect)="typeaheadOnSelect($event)"
   template: `
     <input [(ngModel)]="selectedState"
-           [typeahead]="states"
+           [bsTypeahead]="states"
            [typeaheadOptionField]="'name'"
            (typeaheadOnBlur)="onBlurEvent($event)">
   `

--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -28,6 +28,7 @@ import { ComponentLoader, ComponentLoaderFactory } from '../component-loader/ind
 import { TypeaheadContainerComponent } from './typeahead-container.component';
 import { TypeaheadMatch } from './typeahead-match.class';
 import { getValueFromObject, latinize, tokenize } from './typeahead-utils';
+import { warnOnce } from '../utils/warn-once';
 
 @Directive({ selector: '[bsTypeahead], [typeahead]', exportAs: 'bs-typeahead' })
 export class TypeaheadDirective implements OnInit, OnDestroy {
@@ -36,7 +37,11 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
    */
   @Input() bsTypeahead: any;
   /** @deprecated - please use `bsTypeahead` instead */
-  @Input() typeahead: any;
+  @Input('typeahead')
+  set htmlContent(value: any) {
+    warnOnce('typeahead was deprecated, please use `bsTypeahead` instead');
+    this.bsTypeahead = value;
+  }
   /** minimal no of characters that needs to be entered before
    * typeahead kicks-in. When set to 0, typeahead shows on focus with full
    * list of options (limited as normal by typeaheadOptionsLimit)
@@ -159,12 +164,12 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
     // async should be false in case of array
     if (
       this.typeaheadAsync === undefined &&
-      !(this.typeahead instanceof Observable)
+      !(this.bsTypeahead instanceof Observable)
     ) {
       this.typeaheadAsync = false;
     }
 
-    if (this.typeahead instanceof Observable) {
+    if (this.bsTypeahead instanceof Observable) {
       this.typeaheadAsync = true;
     }
 
@@ -346,7 +351,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
     this._subscriptions.push(
       this.keyUpEventEmitter
         .debounceTime(this.typeaheadWaitMs)
-        .switchMap(() => this.typeahead)
+        .switchMap(() => this.bsTypeahead)
         .subscribe((matches: any[]) => {
           this.finalizeAsyncCall(matches);
         })
@@ -360,7 +365,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
         .mergeMap((value: string) => {
           const normalizedQuery = this.normalizeQuery(value);
 
-          return Observable.from(this.typeahead)
+          return Observable.from(this.bsTypeahead)
             .filter((option: any) => {
               return (
                 option &&

--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -29,11 +29,13 @@ import { TypeaheadContainerComponent } from './typeahead-container.component';
 import { TypeaheadMatch } from './typeahead-match.class';
 import { getValueFromObject, latinize, tokenize } from './typeahead-utils';
 
-@Directive({selector: '[typeahead]', exportAs: 'bs-typeahead'})
+@Directive({ selector: '[bsTypeahead], [typeahead]', exportAs: 'bs-typeahead' })
 export class TypeaheadDirective implements OnInit, OnDestroy {
   /** options source, can be Array of strings, objects or
    * an Observable for external matching process
    */
+  @Input() bsTypeahead: any;
+  /** @deprecated - please use `bsTypeahead` instead */
   @Input() typeahead: any;
   /** minimal no of characters that needs to be entered before
    * typeahead kicks-in. When set to 0, typeahead shows on focus with full
@@ -121,7 +123,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
   /**  if true select the currently highlighted match on blur */
   // @Input() protected typeaheadSelectOnBlur:boolean;
   /**  if false don't focus the input element the typeahead directive is associated with on selection */
-    // @Input() protected typeaheadFocusOnSelect:boolean;
+  // @Input() protected typeaheadFocusOnSelect:boolean;
 
   _container: TypeaheadContainerComponent;
   isTypeaheadOptionsListActive = false;
@@ -136,11 +138,11 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
   private _outsideClickListener: Function;
 
   constructor(private ngControl: NgControl,
-              private element: ElementRef,
-              viewContainerRef: ViewContainerRef,
-              private renderer: Renderer2,
-              cis: ComponentLoaderFactory,
-              private changeDetection: ChangeDetectorRef) {
+    private element: ElementRef,
+    viewContainerRef: ViewContainerRef,
+    private renderer: Renderer2,
+    cis: ComponentLoaderFactory,
+    private changeDetection: ChangeDetectorRef) {
     this._typeahead = cis.createLoader<TypeaheadContainerComponent>(
       element,
       viewContainerRef,
@@ -183,8 +185,8 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
       e.target.value !== undefined
         ? e.target.value
         : e.target.textContent !== undefined
-        ? e.target.textContent
-        : e.target.innerText;
+          ? e.target.textContent
+          : e.target.innerText;
     if (value != null && value.trim().length >= this.typeaheadMinLength) {
       this.typeaheadLoading.emit(true);
       this.keyUpEventEmitter.emit(e.target.value);
@@ -284,7 +286,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
       .attach(TypeaheadContainerComponent)
       // todo: add append to body, after updating positioning service
       .to(this.container)
-      .position({attachment: `${this.dropup ? 'top' : 'bottom'} left`})
+      .position({ attachment: `${this.dropup ? 'top' : 'bottom'} left` })
       .show({
         typeaheadRef: this,
         placement: this.placement,


### PR DESCRIPTION
#3623 

Since more people have encountered the same problem with the usage of the `typeahead` directive, I've made a pull request which solves that problem by adding a prefix to the directive. Because changing the selector will cause a breaking change, I added the selector with the prefix while keeping the old one for now and marking it as deprecated. This is not a fix for us because the `[typeahead]` selector still exists, but we hope that the selector will be removed and switched with our new one in the next release.