### PR TITLE
docs(modal): update description for Component demo at Service examples section

### DIFF
--- a/demo/src/app/components/+modal/modal-section.list.ts
+++ b/demo/src/app/components/+modal/modal-section.list.ts
@@ -63,8 +63,8 @@ export const demoComponentContent: ContentSection[] = [
         html: require('!!raw-loader?lang=markup!./demos/service-component/service-component.html'),
         description: `<p>Creating a modal with component just as easy as it is with template. Just pass your component
           in <code>.show()</code> method as in example, and don't forget to include your component to
-          <code>entryComponents</code> of your NgModule<br> If you passed a component
-          to <code>.show()</code> you can get access to opened modal by injecting BsModalRef. Also you can pass data 
+          <code>entryComponents</code> of your <code>NgModule</code><br> If you passed a component
+          to <code>.show()</code> you can get access to opened modal by injecting <code>BsModalRef</code>. Also you can pass data 
           in your modal by adding <code>initialState</code> field in config. See example for more info</p>`,
         outlet: DemoModalServiceFromComponent
       },


### PR DESCRIPTION
# PR Checklist
 - [x] built and tested the changes locally.
 - [x] updated demos

closes https://github.com/valor-software/ngx-bootstrap/issues/4039

Words `NgModule` and `BsModalRef` were placed inside `code` tag
![compservmoddescrfixed](https://user-images.githubusercontent.com/27342505/37666475-4b4ca170-2c68-11e8-8b31-db62146bce3f.jpg)

