### PR TITLE
docs(pagination): update description for Limits demo

### DIFF
--- a/demo/src/app/components/+pagination/pagination-section.list.ts
+++ b/demo/src/app/components/+pagination/pagination-section.list.ts
@@ -98,7 +98,7 @@ export const demoComponentContent: ContentSection[] = [
         anchor: 'pagination-limit',
         component: require('!!raw-loader?lang=typescript!./demos/limit/limit.ts'),
         html: require('!!raw-loader?lang=markup!./demos/limit/limit.html'),
-        description: `<p>Limit the maximum visible buttons</p>`,
+        description: `<p>Limit the maximum visible pages</p>`,
         outlet: DemoPaginationLimitComponent
       },
       {


### PR DESCRIPTION
# PR Checklist
 - [x] built and tested the changes locally.
 - [x] updated demos.

closes https://github.com/valor-software/ngx-bootstrap/issues/4057

Word `buttons` in demo description was changed, now it's words `pages`:
![buttonsbecamepages](https://user-images.githubusercontent.com/27342505/37779202-843949e2-2df4-11e8-8cdf-21d410aa4bfb.jpg)
