### PR TITLE
feat(accordion): revert changes for accordion key nav support

### DIFF
--- a/demo/src/app/components/+accordion/demos/custom-html/custom-html.html
+++ b/demo/src/app/components/+accordion/demos/custom-html/custom-html.html
@@ -1,15 +1,15 @@
 <accordion>
   <accordion-group>
-    <button class="btn btn-link btn-block clearfix" accordion-heading>
-      <div class="pull-left float-left">I can have markup!</div>
+    <div accordion-heading class="clearfix">
+      I can have markup!
       <span class="badge badge-secondary float-right pull-right">Some HTML here</span>
-    </button>
+    </div>
     This is just some content to illustrate fancy headings.
   </accordion-group>
   <accordion-group>
-    <button class="btn btn-link" accordion-heading>
+    <div accordion-heading>
       I can have markup, too!
-    </button>
+    </div>
     <span class="badge badge-secondary center">And some HTML here</span>
   </accordion-group>
 </accordion>

--- a/src/accordion/accordion-group.component.html
+++ b/src/accordion/accordion-group.component.html
@@ -4,9 +4,9 @@
     <div class="panel-title">
       <div role="button" class="accordion-toggle"
            [attr.aria-expanded]="isOpen">
-        <button class="btn btn-link" *ngIf="heading" [ngClass]="{'text-muted': isDisabled}">
+        <div *ngIf="heading" [ngClass]="{'text-muted': isDisabled}">
           {{ heading }}
-        </button>
+        </div>
         <ng-content select="[accordion-heading]"></ng-content>
       </div>
     </div>


### PR DESCRIPTION
Because of breaking changes need to revert new html structure of accordion, main template and `Custom html` demo.

- Revert accordion component template, changed `button` to `div`
- Revert accordion demo `Custom html`, changed `button` to `div`

### Actual result:
![download 1](https://user-images.githubusercontent.com/3996023/37899542-7f2619d2-30f4-11e8-960f-35710d13ac61.png)

### Expected result:
![download](https://user-images.githubusercontent.com/3996023/37899557-8bb13ab0-30f4-11e8-9f15-7aa194794741.png)

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated tests.
 - [x] added/updated API documentation.
 - [x] added/updated demos.
