### PR TITLE
docs(popover): rename Trigger by input demo

### DIFF
--- a/demo/src/app/components/+popover/demos/index.ts
+++ b/demo/src/app/components/+popover/demos/index.ts
@@ -10,7 +10,7 @@ import { DemoPopoverStylingGlobalComponent } from './styling-global/styling-glob
 import { DemoPopoverStylingLocalComponent } from './styling-local/styling-local';
 import { DemoPopoverTriggersCustomComponent } from './triggers-custom/triggers-custom';
 import { DemoPopoverTriggersManualComponent } from './triggers-manual/triggers-manual';
-import { DemoPopoverTriggerByInput } from './trigger-by-input/trigger-by-input';
+import { DemoPopoverByIsOpenPropComponent } from './trigger-by-isopen-property/trigger-by-isopen-property';
 import { DemoPopoverClassComponent } from './class/class';
 import { DemoPopoverOutsideClickComponent } from './outside-click/outside-click';
 import { DemoPopoverEventsComponent } from './events/events';
@@ -29,7 +29,7 @@ export const DEMO_COMPONENTS = [
   DemoPopoverStylingLocalComponent,
   DemoPopoverTriggersCustomComponent,
   DemoPopoverTriggersManualComponent,
-  DemoPopoverTriggerByInput,
+  DemoPopoverByIsOpenPropComponent,
   DemoPopoverClassComponent,
   DemoPopoverOutsideClickComponent,
   DemoPopoverEventsComponent,

--- a/demo/src/app/components/+popover/demos/trigger-by-input/trigger-by-input.ts
+++ b/demo/src/app/components/+popover/demos/trigger-by-input/trigger-by-input.ts
@@ -1,9 +1,0 @@
-import { Component } from '@angular/core';
-
-@Component({
-  selector: 'demo-popover-trigger-by-input',
-  templateUrl: './trigger-by-input.html'
-})
-export class DemoPopoverTriggerByInput {
-  isOpen = false;
-}

--- a/demo/src/app/components/+popover/demos/trigger-by-isopen-property/trigger-by-isopen-property.html
+++ b/demo/src/app/components/+popover/demos/trigger-by-isopen-property/trigger-by-isopen-property.html
@@ -1,5 +1,5 @@
 <p>
-  <span popover="Hello there! I was triggered by input"
+  <span popover="Hello there! I was triggered by changing isOpen property"
         triggers=""  [isOpen]="isOpen">
   This text has attached popover
   </span>

--- a/demo/src/app/components/+popover/demos/trigger-by-isopen-property/trigger-by-isopen-property.ts
+++ b/demo/src/app/components/+popover/demos/trigger-by-isopen-property/trigger-by-isopen-property.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'demo-popover-trigger-by-isopen',
+  templateUrl: './trigger-by-isopen-property.html'
+})
+export class DemoPopoverByIsOpenPropComponent {
+  isOpen = false;
+}

--- a/demo/src/app/components/+popover/popover-section.list.ts
+++ b/demo/src/app/components/+popover/popover-section.list.ts
@@ -9,7 +9,7 @@ import { DemoPopoverConfigComponent } from './demos/config/config';
 import { DemoPopoverOutsideClickComponent } from './demos/outside-click/outside-click';
 import { DemoPopoverTriggersCustomComponent } from './demos/triggers-custom/triggers-custom';
 import { DemoPopoverTriggersManualComponent } from './demos/triggers-manual/triggers-manual';
-import { DemoPopoverTriggerByInput } from './demos/trigger-by-input/trigger-by-input';
+import { DemoPopoverByIsOpenPropComponent } from './demos/trigger-by-isopen-property/trigger-by-isopen-property';
 import { DemoPopoverStylingLocalComponent } from './demos/styling-local/styling-local';
 import { DemoPopoverClassComponent } from './demos/class/class';
 import { DemoPopoverContextComponent } from './demos/popover-context/popover-context';
@@ -22,8 +22,8 @@ import { ExamplesComponent } from '../../docs/demo-section-components/demo-examp
 import { ApiSectionsComponent } from '../../docs/demo-section-components/demo-api-section/index';
 
 import {
-NgApiDocComponent,
-NgApiDocConfigComponent
+  NgApiDocComponent,
+  NgApiDocConfigComponent
 } from '../../docs/api-docs';
 
 export const demoComponentContent: ContentSection[] = [
@@ -140,12 +140,12 @@ export const demoComponentContent: ContentSection[] = [
         outlet: DemoPopoverTriggersManualComponent
       },
       {
-        title: 'Trigger by input',
-        anchor: 'trigger-by-input',
-        component: require('!!raw-loader?lang=typescript!./demos/trigger-by-input/trigger-by-input.ts'),
-        html: require('!!raw-loader?lang=markup!./demos/trigger-by-input/trigger-by-input.html'),
+        title: 'Trigger by isOpen property',
+        anchor: 'trigger-by-isopen-property',
+        component: require('!!raw-loader?lang=typescript!./demos/trigger-by-isopen-property/trigger-by-isopen-property.ts'),
+        html: require('!!raw-loader?lang=markup!./demos/trigger-by-isopen-property/trigger-by-isopen-property.html'),
         description: `<p>You can show/hide popover by switching <code>isOpen</code> property</p>`,
-        outlet: DemoPopoverTriggerByInput
+        outlet: DemoPopoverByIsOpenPropComponent
       },
       {
         title: 'Component level styling',


### PR DESCRIPTION
# PR Checklist
 - [x] built and tested the changes locally.
 - [x] updated demos.

Closes https://github.com/valor-software/ngx-bootstrap/issues/4100

What was done:
- [x] demo was renamed to `Trigger by isOpen property`
- [x] demo component was renamed to fit angular styliguides (previous name was errored)
Two screenshots with highlighted changes are attached:
![triggerdemo](https://user-images.githubusercontent.com/27342505/37912186-9033ad18-311a-11e8-8bc0-8c25a5936278.jpg)
![codechanges](https://user-images.githubusercontent.com/27342505/37912197-99d67954-311a-11e8-868f-3320f3757116.jpg)
