### PR TITLE
feat(timepicker): Updated timepicker component to bootstrap 4

### DIFF
--- a/src/spec/timepicker/timepicker.component.spec.ts
+++ b/src/spec/timepicker/timepicker.component.spec.ts
@@ -533,9 +533,7 @@ describe('Component: TimepickerComponent', () => {
       fixture.detectChanges();
       fixture.whenStable().then(() => {
         const buttonsHidden = fixture.nativeElement.querySelector('a.btn');
-        expect(buttonsHidden.parentElement.parentElement.className).toContain(
-          'hidden'
-        );
+        expect(buttonsHidden.parentElement.parentElement.hasAttribute('hidden')).toEqual(true)
       });
     });
   });

--- a/src/timepicker/timepicker.component.html
+++ b/src/timepicker/timepicker.component.html
@@ -1,6 +1,6 @@
 <table>
   <tbody>
-  <tr class="text-center" [class.hidden]="!showSpinners">
+  <tr class="text-center" [hidden]="!showSpinners">
     <!-- increment hours button-->
     <td>
       <a class="btn btn-link" [class.disabled]="!canIncrementHours || !isEditable"
@@ -87,7 +87,7 @@
       </button>
     </td>
   </tr>
-  <tr class="text-center" [class.hidden]="!showSpinners">
+  <tr class="text-center" [hidden]="!showSpinners">
     <!-- decrement hours button-->
     <td>
       <a class="btn btn-link" [class.disabled]="!canDecrementHours || !isEditable"


### PR DESCRIPTION
 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.

Bootstrap 4 removed .hidden class.
[bootstrap migration guide](https://getbootstrap.com/docs/4.0/migration/#responsive-utilities)

> The .hidden and .show classes have been removed because they conflicted with jQuery’s $(...).hide() and $(...).show() methods. Instead, try toggling the [hidden] attribute or use inline styles like style="display: none;" and style="display: block;".