### PR TITLE
docs(tooltip): move description for append to body demo to correct place

### DIFF
--- a/demo/src/app/components/+tooltip/tooltip-section.list.ts
+++ b/demo/src/app/components/+tooltip/tooltip-section.list.ts
@@ -94,6 +94,10 @@ export const demoComponentContent: ContentSection[] = [
         anchor: 'append-to-body',
         component: require('!!raw-loader?lang=typescript!./demos/container/container.ts'),
         html: require('!!raw-loader?lang=markup!./demos/container/container.html'),
+        description: `<p>When you have some styles on a parent element that interfere with a tooltip,
+          you’ll want to specify a <code>container="body"</code> so that the tooltip’s HTML will be
+          appended to body. This will help to avoid rendering problems in more complex components
+          (like our input groups, button groups, etc) or inside elements with <code>overflow: hidden</code></p>`,
         outlet: DemoTooltipContainerComponent
       },
       {
@@ -101,10 +105,6 @@ export const demoComponentContent: ContentSection[] = [
         anchor: 'config-defaults',
         component: require('!!raw-loader?lang=typescript!./demos/config/config.ts'),
         html: require('!!raw-loader?lang=markup!./demos/config/config.html'),
-        description: `<p>When you have some styles on a parent element that interfere with a tooltip,
-          you’ll want to specify a <code>container="body"</code> so that the tooltip’s HTML will be
-          appended to body. This will help to avoid rendering problems in more complex components
-          (like our input groups, button groups, etc) or inside elements with <code>overflow: hidden</code></p>`,
         outlet: DemoTooltipConfigComponent
       },
       {


### PR DESCRIPTION
# PR Checklist
 - [x] built and tested the changes locally.
 - [x] updated demos.

Fix description for Append to Body demo (it was at Configuring defaults demo)
How it was:
![wrongplacement](https://user-images.githubusercontent.com/27342505/38736319-528d83d0-3f34-11e8-8484-44f8ed8654fa.jpg)
Where it placed now:
![correct](https://user-images.githubusercontent.com/27342505/38736338-60af38c8-3f34-11e8-8c71-2e06fbcabe38.jpg)

